### PR TITLE
Fix block classification and overhaul the loader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  unittest:
+    name: Block classification tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      # bobs_blocks.py has no ComfyUI or torch dependency, so the mapping logic
+      # is testable on a bare interpreter.
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ This node allows you to go beyond a single strength slider and specify different
 
 -   **Dual Model Support**: Separate, optimized loaders for `SDXL` and `FLUX` models, each tailored to the architecture's specific blocks.
 -   **Granular Block-Level Control**: Fine-tune the strength of a LoRA on different conceptual parts of the diffusion model.
--   **Intelligent Presets**: Comes with pre-configured presets for common use cases like `Character`, `Style`, `Concept`, and `Fix Hands/Anatomy`.
+-   **Intelligent Presets**: Comes with pre-configured presets for common use cases like `Character`, `Style`, `Concept`, `Detail & Texture` and `Fix Hands/Anatomy`.
 -   **Full Customization**: Set the `preset` to `Custom` to get direct slider control over every block for ultimate fine-tuning.
--   **Robust LoRA Compatibility**: Intelligently handles multiple LoRA naming conventions (e.g., `lora_unet_...`, `unet...`, `lora_transformer_...`, etc.) to ensure broad compatibility with community-made files.
+-   **Dialect-proof LoRA compatibility**: Classification runs on the *canonical model key* each patch targets, after ComfyUI has translated the LoRA's own naming scheme. Every format ComfyUI can load — kohya `lora_unet_*`, OneTrainer `lora_transformer_*`, diffusers `transformer.*`, LyCORIS, DiffSynth, PEFT — is bucketed correctly, including fused `qkv` / `linear1` patches.
+-   **Geometry-aware FLUX blocks**: Block ranges are derived from the loaded model's own `depth` / `depth_single_blocks`, so FLUX.1 dev/schnell and pruned or distilled variants all map correctly instead of falling into "Other Tensors".
+-   **Per-block report**: A third `info` output (and a matching console log) shows, per block, the weight used, how many tensors were found, and how many were actually patched.
+-   **Optional CLIP**: leave the `clip` input unconnected to patch the model only.
 -   **Standard LoRA Functionality**: To use it like a standard LoRA loader, simply select the `Full (Normal LoRA)` preset.
 
 ## Installation
@@ -33,15 +36,68 @@ This node allows you to go beyond a single strength slider and specify different
 
 1.  In ComfyUI, add the node by right-clicking, selecting "Add Node," and navigating to the `Bobs_Nodes` category.
 2.  Choose either **Bobs LoRA Loader (SDXL)** or **Bobs LoRA Loader (FLUX)** depending on your base model.
-3.  Connect your `MODEL` and `CLIP` outputs into the corresponding inputs on the node.
+3.  Connect your `MODEL` and `CLIP` outputs into the corresponding inputs on the node. `CLIP` is optional — leave it unconnected to patch the model only.
 4.  Select the LoRA you wish to apply from the `lora_name` dropdown.
-5.  Use the `preset` dropdown to quickly apply a set of block weights for a specific purpose (e.g., "Character" to focus on subject detail).
-6.  For maximum control, set the `preset` to `Custom` and adjust the individual block sliders that appear.
+5.  Use the `preset` dropdown to quickly apply a set of block weights for a specific purpose (e.g. "Character" to focus on subject detail).
+6.  For maximum control, set the `preset` to `Custom` and adjust the individual block sliders.
 7.  The main `strength` slider acts as a global multiplier for all other block weights, allowing you to scale the entire effect up or down.
+8.  Hook the `info` output up to a preview-text node (or read the console) to see exactly which blocks the LoRA actually touched.
+
+> **Note on presets:** a preset other than `Custom` *overrides* the sliders — it does not blend with them. Only `strength` still applies on top.
+
+### Reading the `info` output
+
+```
+[FLUX] mylora.safetensors  (preset: Character)
+block                                     weight   found  applied
+Text Conditioning                           1.00       1        1
+Early Downsampling (Composition)            0.60      16       16
+Mid Upsampling (Detail Generation)          0.00      48        0
+Text Encoder                                1.00       4        4
+TOTAL                                                200      133
+```
+
+-   **found** — tensors in this LoRA that belong to that block.
+-   **applied** — tensors actually patched. A block with `found > 0` and `applied 0` was skipped because its weight is `0.00`.
+-   A block with `found 0` means the LoRA simply contains no weights for it; the console log spells this out.
+
+## Block Layout
+
+### FLUX
+
+Ranges below are for the canonical FLUX.1 geometry (19 double-stream blocks, 38 single-stream blocks). Other depths are scaled proportionally.
+
+| Block | Covers |
+|---|---|
+| Text Encoder | CLIP-L / T5 text encoder weights |
+| Text Conditioning | `txt_in` |
+| Timestep Embedding | `time_in` |
+| Image Hint | `img_in` |
+| Guidance Embedding | `guidance_in` |
+| Vector Embedding | `vector_in` |
+| Early Downsampling (Composition) | `double_blocks.0–3` |
+| Mid Downsampling (Subject & Concept) | `double_blocks.4–7` |
+| Late Downsampling (Refinement) | `double_blocks.8–9` |
+| Core/Middle Block (Style Focus) | `double_blocks.10–18`, `single_blocks.0–7` |
+| Early Upsampling (Initial Style) | `single_blocks.8–15` |
+| Mid Upsampling (Detail Generation) | `single_blocks.16–31` |
+| Late Upsampling (Final Textures) | `single_blocks.32–37` |
+| Final Output Layer (Latent Projection) | `final_layer` |
+| Other Tensors | anything unmatched (normally empty) |
+
+### SDXL
+
+| Block | Covers |
+|---|---|
+| Text Encoder | CLIP-L / CLIP-G |
+| Input Blocks | `input_blocks.*` |
+| Middle Block | `middle_block.*` |
+| Output Blocks | `output_blocks.*` |
+| Other Tensors | `time_embed`, `label_emb`, `out.*` |
 
 ## Why Use Block-Weighted LoRA?
 
-A single LoRA file often contains training for multiple concepts (e.g., a character's face, their clothing, and the overall artistic style). A standard LoRA loader applies the LoRA with one uniform strength across the entire model.
+A single LoRA file often contains training for multiple concepts (e.g. a character's face, their clothing, and the overall artistic style). A standard LoRA loader applies the LoRA with one uniform strength across the entire model.
 
 This can be limiting. For example:
 -   You might want a character's features but not the stiff, overbaked style it was trained with.
@@ -49,13 +105,30 @@ This can be limiting. For example:
 
 By assigning different strengths to different model blocks, you can selectively emphasize or de-emphasize these aspects. The SDXL loader provides coarse control over the main UNet stages, while the FLUX loader offers even finer-grained control over conceptual phases like "Composition," "Refinement," and "Final Textures."
 
-## Changelog / What's New
+## Development
 
-### Major Overhaul of LoRA Classification Logic
+The block-classification logic lives in `bobs_blocks.py` and deliberately imports nothing from ComfyUI or torch, so it can be tested on a bare interpreter:
 
-This version addresses a critical issue where many LoRA files were not being correctly categorized, causing a large number of weights to be ignored or misapplied. The core classification logic for both loaders has been completely rewritten.
+```bash
+python -m unittest discover -s tests -v
+```
 
--   **FLUX Loader Fix**: The loader's regular expressions and classification rules have been completely overhauled to correctly handle all block types, including complex `time_text_embed` keys and all layers within attention blocks (`q`, `k`, `v`, `out`).
--   **SDXL Loader Fix**: The loader is now compatible with LoRAs that use the `unet.` naming convention (common in some community models), in addition to the standard `lora_unet_...` format. This significantly improves compatibility.
+## Changelog
 
-The result is a far more reliable and robust tool that ensures the settings on your sliders accurately reflect the changes being applied to the model. The "Other Tensors" count in the logs should now be zero for all supported LoRAs.
+### 1.1.0
+
+**Block weighting now actually works.** This release fixes a defect that made the per-block sliders unreliable for every LoRA.
+
+-   **Fixed: patches were classified by the wrong key.** ComfyUI's `key_map` maps a LoRA's key name to the *model state-dict key string* it targets (or a `(key, offset)` tuple for fused FLUX `qkv` / `linear1` weights). The previous code treated those values as `nn.Module` objects and indexed `[0]` on them, which on a string yields its first *character*. Every patch therefore resolved through a single arbitrary lookup, so all weights were effectively bucketed together rather than per block. Classification now runs directly on the canonical target key, and fused `(key, offset)` patches are unpacked correctly.
+-   **Fixed: SDXL "unclassified" patches were silently discarded.** Anything that did not match input/middle/output/text-encoder was collected and then never applied. Those tensors now have their own `Other Tensors` weight.
+-   **Fixed: model and CLIP patches are routed properly.** The FLUX loader previously pushed every patch group at its block strength into *both* the model and the CLIP patcher, with no separate text-encoder control. Model and text-encoder patches are now split by which key map owns the key, and FLUX gains a `Text Encoder` slider.
+-   **Fixed: dead FLUX index ranges.** The old table mapped `double_blocks.19–28`, which do not exist on any FLUX model. Ranges are now computed from the loaded model's own `depth` / `depth_single_blocks`, so pruned and distilled variants map correctly too.
+-   **Security: no more bare `torch.load`.** Non-safetensors LoRAs are read through `comfy.utils.load_torch_file(..., safe_load=True)`, which sets `weights_only=True`. Loading a `.ckpt`/`.pt` LoRA no longer risks executing pickled code.
+-   **Added: LoRA file caching.** The file is re-read only when its path, size or mtime changes, instead of on every graph execution.
+-   **Added: `info` string output** with a per-block table of weight / found / applied, plus console logging that explains empty blocks.
+-   **Added: `comfy.lora_convert` support** (guarded), so BFL-control, Wan-Fun and USO LoRAs are converted before loading.
+-   **Added: optional `clip` input**, tooltips on every widget, node descriptions, and a `Detail & Texture` preset for both families.
+-   **Added: unit tests** and CI covering the classification and strength-resolution logic.
+-   Errors (missing file, unreadable file, no matching keys) now return the graph inputs unchanged with an explanation on the `info` output instead of only logging.
+
+**Compatibility:** existing workflows keep working. New widgets were appended after the existing ones and new outputs after the existing ones, so saved widget values and links stay aligned. Expect different — correct — results from the same slider settings, since the sliders previously did not target the blocks they named.

--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,21 @@
-from .bobs_lora_loader import BobsLoraLoaderFlux, BobsLoraLoaderSdxl
+"""Bobs LoRA Loader — block-weighted LoRA loading for ComfyUI (FLUX + SDXL)."""
 
-NODE_CLASS_MAPPINGS = {
-    "BobsLoraLoaderFlux": BobsLoraLoaderFlux,
-    "BobsLoraLoaderSdxl": BobsLoraLoaderSdxl,
-}
+import logging
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "BobsLoraLoaderFlux": "Bobs LoRA Loader (FLUX)",
-    "BobsLoraLoaderSdxl": "Bobs LoRA Loader (SDXL)",
-}
+from .bobs_lora_loader import (
+    NODE_CLASS_MAPPINGS,
+    NODE_DISPLAY_NAME_MAPPINGS,
+    BobsLoraLoaderFlux,
+    BobsLoraLoaderSdxl,
+)
 
-print("✨ Bobs LoRA Loader nodes loaded! ✨")
+__all__ = [
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+    "BobsLoraLoaderFlux",
+    "BobsLoraLoaderSdxl",
+]
+
+logging.getLogger("BobsLoraLoader").info(
+    "Bobs LoRA Loader: %d nodes registered.", len(NODE_CLASS_MAPPINGS)
+)

--- a/bobs_blocks.py
+++ b/bobs_blocks.py
@@ -1,0 +1,435 @@
+"""
+Block definitions, presets and key-classification logic for Bobs LoRA Loader.
+
+This module deliberately imports nothing from ComfyUI or torch so the mapping
+logic can be exercised standalone (see ``tests/test_bobs_blocks.py``).
+
+Everything here classifies *model state dict keys* — i.e. the values stored in
+ComfyUI's ``key_map`` (``diffusion_model.double_blocks.3.img_attn.qkv.weight``,
+``clip_l.transformer.text_model.encoder.layers.0.self_attn.k_proj.weight``, ...)
+— not the raw key names found inside a LoRA file. ComfyUI has already done the
+work of translating every exporter dialect (kohya, OneTrainer, diffusers,
+lycoris, DiffSynth, ...) into these canonical names, so classifying on them is
+both simpler and dialect-proof.
+"""
+
+import re
+from typing import Dict, List, Sequence, Tuple
+
+# -----------------------------------------------------------------------------#
+#                                 BLOCK NAMES                                  #
+# -----------------------------------------------------------------------------#
+#
+# NOTE ON ORDERING: ComfyUI serialises widget values positionally, so the order
+# of these lists is part of the node's saved-workflow contract. Never reorder or
+# remove an entry — only append new ones at the end.
+
+FLUX_TEXT_CONDITIONING = "Text Conditioning"
+FLUX_TIMESTEP = "Timestep Embedding"
+FLUX_IMAGE_HINT = "Image Hint"
+FLUX_GUIDANCE = "Guidance Embedding"
+FLUX_VECTOR = "Vector Embedding"
+FLUX_EARLY_DOWN = "Early Downsampling (Composition)"
+FLUX_MID_DOWN = "Mid Downsampling (Subject & Concept)"
+FLUX_LATE_DOWN = "Late Downsampling (Refinement)"
+FLUX_CORE = "Core/Middle Block (Style Focus)"
+FLUX_EARLY_UP = "Early Upsampling (Initial Style)"
+FLUX_MID_UP = "Mid Upsampling (Detail Generation)"
+FLUX_LATE_UP = "Late Upsampling (Final Textures)"
+FLUX_FINAL = "Final Output Layer (Latent Projection)"
+FLUX_OTHER = "Other Tensors"
+FLUX_TEXT_ENCODER = "Text Encoder"  # appended in 1.1.0 — keep last
+
+ALL_FLUX_BLOCKS: List[str] = [
+    FLUX_TEXT_CONDITIONING,
+    FLUX_TIMESTEP,
+    FLUX_IMAGE_HINT,
+    FLUX_GUIDANCE,
+    FLUX_VECTOR,
+    FLUX_EARLY_DOWN,
+    FLUX_MID_DOWN,
+    FLUX_LATE_DOWN,
+    FLUX_CORE,
+    FLUX_EARLY_UP,
+    FLUX_MID_UP,
+    FLUX_LATE_UP,
+    FLUX_FINAL,
+    FLUX_OTHER,
+    FLUX_TEXT_ENCODER,
+]
+
+SDXL_TEXT_ENCODER = "Text Encoder"
+SDXL_INPUT_BLOCKS = "Input Blocks"
+SDXL_MIDDLE_BLOCK = "Middle Block"
+SDXL_OUTPUT_BLOCKS = "Output Blocks"
+SDXL_OTHER = "Other Tensors"  # appended in 1.1.0 — keep last
+
+ALL_SDXL_BLOCKS: List[str] = [
+    SDXL_TEXT_ENCODER,
+    SDXL_INPUT_BLOCKS,
+    SDXL_MIDDLE_BLOCK,
+    SDXL_OUTPUT_BLOCKS,
+    SDXL_OTHER,
+]
+
+# The single block per family that receives CLIP / text-encoder patches.
+TEXT_ENCODER_BLOCK = {"FLUX": FLUX_TEXT_ENCODER, "SDXL": SDXL_TEXT_ENCODER}
+
+BLOCK_TOOLTIPS: Dict[str, str] = {
+    FLUX_TEXT_ENCODER: "CLIP-L / T5 text encoder weights. Lower this to keep a LoRA's look while weakening its trigger words.",
+    FLUX_TEXT_CONDITIONING: "diffusion_model.txt_in — projects text embeddings into the transformer.",
+    FLUX_TIMESTEP: "diffusion_model.time_in — timestep embedding.",
+    FLUX_IMAGE_HINT: "diffusion_model.img_in — latent patch embedding.",
+    FLUX_GUIDANCE: "diffusion_model.guidance_in — distilled guidance embedding.",
+    FLUX_VECTOR: "diffusion_model.vector_in — pooled CLIP vector embedding.",
+    FLUX_EARLY_DOWN: "First fifth of the double-stream blocks. Global composition and pose.",
+    FLUX_MID_DOWN: "Second fifth of the double-stream blocks. Subject identity and concept.",
+    FLUX_LATE_DOWN: "Tail of the first half of the double-stream blocks. Structural refinement.",
+    FLUX_CORE: "Late double-stream plus early single-stream blocks. Dominant style carrier.",
+    FLUX_EARLY_UP: "Early-middle single-stream blocks. Broad stylistic treatment.",
+    FLUX_MID_UP: "Middle single-stream blocks. Detail generation.",
+    FLUX_LATE_UP: "Final single-stream blocks. Fine texture, grain and skin detail.",
+    FLUX_FINAL: "diffusion_model.final_layer — projection back to latent space.",
+    FLUX_OTHER: "Any UNet tensor that did not match a block above. Normally near zero.",
+    SDXL_INPUT_BLOCKS: "UNet down path (diffusion_model.input_blocks.*). Composition and structure.",
+    SDXL_MIDDLE_BLOCK: "UNet bottleneck (diffusion_model.middle_block.*). Concept and style core.",
+    SDXL_OUTPUT_BLOCKS: "UNet up path (diffusion_model.output_blocks.*). Style, detail and texture.",
+    SDXL_OTHER: "UNet tensors outside the three stages (time_embed, label_emb, out.*).",
+}
+BLOCK_TOOLTIPS[SDXL_TEXT_ENCODER] = BLOCK_TOOLTIPS[FLUX_TEXT_ENCODER]
+
+# -----------------------------------------------------------------------------#
+#                             PRESET  DEFINITIONS                              #
+# -----------------------------------------------------------------------------#
+#
+# ``strength`` is a preset-level multiplier stacked on top of the node's global
+# strength; ``block_weights`` is the per-block multiplier. A block missing from
+# ``block_weights`` falls back to 1.0.
+#
+# Preset names are serialised by value, so appending new presets is safe.
+
+LORA_BLOCK_PRESETS: Dict[str, Dict[str, Dict]] = {
+    "FLUX": {
+        "Custom": {},
+        "Full (Normal LoRA)": {
+            "strength": 1.0,
+            "block_weights": {name: 1.0 for name in ALL_FLUX_BLOCKS},
+        },
+        "Character": {
+            "strength": 1.0,
+            "block_weights": {
+                FLUX_TEXT_ENCODER: 1.0,
+                FLUX_TEXT_CONDITIONING: 1.0,
+                FLUX_TIMESTEP: 1.0,
+                FLUX_IMAGE_HINT: 1.0,
+                FLUX_GUIDANCE: 1.0,
+                FLUX_VECTOR: 1.0,
+                FLUX_EARLY_DOWN: 0.6,
+                FLUX_MID_DOWN: 1.0,
+                FLUX_LATE_DOWN: 0.4,
+                FLUX_CORE: 1.0,
+                FLUX_EARLY_UP: 0.1,
+                FLUX_MID_UP: 0.0,
+                FLUX_LATE_UP: 0.0,
+                FLUX_FINAL: 0.0,
+                FLUX_OTHER: 1.0,
+            },
+        },
+        "Style": {
+            "strength": 1.0,
+            "block_weights": {
+                FLUX_TEXT_ENCODER: 0.2,
+                FLUX_TEXT_CONDITIONING: 0.2,
+                FLUX_TIMESTEP: 1.0,
+                FLUX_IMAGE_HINT: 1.0,
+                FLUX_GUIDANCE: 1.0,
+                FLUX_VECTOR: 1.0,
+                FLUX_EARLY_DOWN: 0.1,
+                FLUX_MID_DOWN: 0.0,
+                FLUX_LATE_DOWN: 0.2,
+                FLUX_CORE: 0.5,
+                FLUX_EARLY_UP: 1.0,
+                FLUX_MID_UP: 1.0,
+                FLUX_LATE_UP: 1.0,
+                FLUX_FINAL: 1.0,
+                FLUX_OTHER: 1.0,
+            },
+        },
+        "Concept": {
+            "strength": 1.0,
+            "block_weights": {
+                FLUX_TEXT_ENCODER: 1.0,
+                FLUX_TEXT_CONDITIONING: 1.0,
+                FLUX_TIMESTEP: 1.0,
+                FLUX_IMAGE_HINT: 1.0,
+                FLUX_GUIDANCE: 1.0,
+                FLUX_VECTOR: 1.0,
+                FLUX_EARLY_DOWN: 1.0,
+                FLUX_MID_DOWN: 0.9,
+                FLUX_LATE_DOWN: 0.6,
+                FLUX_CORE: 0.7,
+                FLUX_EARLY_UP: 0.5,
+                FLUX_MID_UP: 0.3,
+                FLUX_LATE_UP: 0.1,
+                FLUX_FINAL: 0.0,
+                FLUX_OTHER: 1.0,
+            },
+        },
+        "Detail & Texture": {
+            "strength": 1.0,
+            "block_weights": {
+                FLUX_TEXT_ENCODER: 0.0,
+                FLUX_TEXT_CONDITIONING: 0.0,
+                FLUX_TIMESTEP: 1.0,
+                FLUX_IMAGE_HINT: 1.0,
+                FLUX_GUIDANCE: 1.0,
+                FLUX_VECTOR: 1.0,
+                FLUX_EARLY_DOWN: 0.0,
+                FLUX_MID_DOWN: 0.0,
+                FLUX_LATE_DOWN: 0.0,
+                FLUX_CORE: 0.2,
+                FLUX_EARLY_UP: 0.5,
+                FLUX_MID_UP: 1.0,
+                FLUX_LATE_UP: 1.0,
+                FLUX_FINAL: 1.0,
+                FLUX_OTHER: 0.0,
+            },
+        },
+        "Fix Hands/Anatomy": {
+            "strength": 0.4,
+            "block_weights": {
+                FLUX_TEXT_ENCODER: 0.0,
+                FLUX_TEXT_CONDITIONING: 0.2,
+                FLUX_TIMESTEP: 1.0,
+                FLUX_IMAGE_HINT: 1.0,
+                FLUX_GUIDANCE: 1.0,
+                FLUX_VECTOR: 1.0,
+                FLUX_EARLY_DOWN: 1.0,
+                FLUX_MID_DOWN: 0.3,
+                FLUX_LATE_DOWN: 0.0,
+                FLUX_CORE: 0.0,
+                FLUX_EARLY_UP: 0.0,
+                FLUX_MID_UP: 0.0,
+                FLUX_LATE_UP: 0.0,
+                FLUX_FINAL: 0.0,
+                FLUX_OTHER: 0.0,
+            },
+        },
+    },
+
+    "SDXL": {
+        "Custom": {},
+        "Full (Normal LoRA)": {
+            "strength": 1.0,
+            "block_weights": {b: 1.0 for b in ALL_SDXL_BLOCKS},
+        },
+        "Character": {
+            "strength": 1.0,
+            "block_weights": {
+                SDXL_TEXT_ENCODER: 1.0,
+                SDXL_INPUT_BLOCKS: 1.0,
+                SDXL_MIDDLE_BLOCK: 1.0,
+                SDXL_OUTPUT_BLOCKS: 0.2,
+                SDXL_OTHER: 1.0,
+            },
+        },
+        "Style": {
+            "strength": 1.0,
+            "block_weights": {
+                SDXL_TEXT_ENCODER: 0.0,
+                SDXL_INPUT_BLOCKS: 0.2,
+                SDXL_MIDDLE_BLOCK: 0.5,
+                SDXL_OUTPUT_BLOCKS: 1.0,
+                SDXL_OTHER: 1.0,
+            },
+        },
+        "Concept": {
+            "strength": 1.0,
+            "block_weights": {
+                SDXL_TEXT_ENCODER: 1.0,
+                SDXL_INPUT_BLOCKS: 0.8,
+                SDXL_MIDDLE_BLOCK: 0.7,
+                SDXL_OUTPUT_BLOCKS: 0.5,
+                SDXL_OTHER: 1.0,
+            },
+        },
+        "Detail & Texture": {
+            "strength": 1.0,
+            "block_weights": {
+                SDXL_TEXT_ENCODER: 0.0,
+                SDXL_INPUT_BLOCKS: 0.0,
+                SDXL_MIDDLE_BLOCK: 0.2,
+                SDXL_OUTPUT_BLOCKS: 1.0,
+                SDXL_OTHER: 0.0,
+            },
+        },
+        "Fix Hands/Anatomy": {
+            "strength": 0.4,
+            "block_weights": {
+                SDXL_TEXT_ENCODER: 0.2,
+                SDXL_INPUT_BLOCKS: 1.0,
+                SDXL_MIDDLE_BLOCK: 0.4,
+                SDXL_OUTPUT_BLOCKS: 0.0,
+                SDXL_OTHER: 0.0,
+            },
+        },
+    },
+}
+
+ALL_BLOCKS = {"FLUX": ALL_FLUX_BLOCKS, "SDXL": ALL_SDXL_BLOCKS}
+
+# -----------------------------------------------------------------------------#
+#                              KEY NORMALISATION                               #
+# -----------------------------------------------------------------------------#
+
+_SEPARATORS = re.compile(r"[./:]+")
+_REPEATED_US = re.compile(r"_{2,}")
+
+
+def normalize_key(key: str) -> str:
+    """Lower-case a key and collapse ``. / :`` into single underscores.
+
+    A leading underscore is always present in the result so that head-token
+    checks such as ``"_txt_in"`` also match a key that *starts* with the token.
+    """
+    k = _SEPARATORS.sub("_", key).lower()
+    k = _REPEATED_US.sub("_", k)
+    return k if k.startswith("_") else "_" + k
+
+
+# -----------------------------------------------------------------------------#
+#                             FLUX  CLASSIFICATION                             #
+# -----------------------------------------------------------------------------#
+
+# Canonical FLUX.1 geometry: 19 double-stream blocks, 38 single-stream blocks.
+FLUX_DEFAULT_DEPTH = 19
+FLUX_DEFAULT_DEPTH_SINGLE = 38
+
+# Fractional split points across each stack. The fractions are chosen so the
+# canonical geometry reproduces the index ranges this node has always used,
+# while non-standard depths (Flex, Chroma, pruned/distilled FLUX variants)
+# scale proportionally instead of falling out into "Other Tensors".
+_DOUBLE_SPLITS: Sequence[Tuple[float, str]] = (
+    (4 / 19, FLUX_EARLY_DOWN),
+    (8 / 19, FLUX_MID_DOWN),
+    (10 / 19, FLUX_LATE_DOWN),
+    (1.0, FLUX_CORE),
+)
+_SINGLE_SPLITS: Sequence[Tuple[float, str]] = (
+    (8 / 38, FLUX_CORE),
+    (16 / 38, FLUX_EARLY_UP),
+    (32 / 38, FLUX_MID_UP),
+    (1.0, FLUX_LATE_UP),
+)
+
+# ``single`` must be tested before ``double``: "single_transformer_blocks_3"
+# would otherwise also satisfy the double-stream pattern.
+_RE_SINGLE_BLOCK = re.compile(r"_(?:single_blocks|single_transformer_blocks)_(\d+)(?:_|$)")
+_RE_DOUBLE_BLOCK = re.compile(r"_(?:double_blocks|transformer_blocks)_(\d+)(?:_|$)")
+
+# Head / tail tokens, most specific first.
+_FLUX_TOKEN_MAP: Sequence[Tuple[str, str]] = (
+    ("_time_text_embed_guidance_embedder", FLUX_GUIDANCE),
+    ("_time_text_embed_text_embedder", FLUX_VECTOR),
+    ("_time_text_embed_timestep_embedder", FLUX_TIMESTEP),
+    ("_time_text_embed", FLUX_TIMESTEP),
+    ("_guidance_in", FLUX_GUIDANCE),
+    ("_vector_in", FLUX_VECTOR),
+    ("_time_in", FLUX_TIMESTEP),
+    ("_txt_in", FLUX_TEXT_CONDITIONING),
+    ("_context_embedder", FLUX_TEXT_CONDITIONING),   # diffusers name for txt_in
+    ("_img_in", FLUX_IMAGE_HINT),
+    ("_x_embedder", FLUX_IMAGE_HINT),                # diffusers name for img_in
+    ("_final_layer", FLUX_FINAL),
+    ("_proj_out", FLUX_FINAL),                       # diffusers name for final_layer
+    ("_norm_out", FLUX_FINAL),
+)
+
+
+def _stack_boundaries(splits: Sequence[Tuple[float, str]], depth: int) -> List[Tuple[int, str]]:
+    """Turn fractional split points into ``(upper_exclusive_index, block)`` pairs."""
+    boundaries: List[Tuple[int, str]] = []
+    previous = 0
+    for fraction, name in splits:
+        upper = max(int(round(fraction * depth)), previous)
+        boundaries.append((upper, name))
+        previous = upper
+    if boundaries:
+        # The last bucket always absorbs the tail, whatever rounding did.
+        boundaries[-1] = (depth, boundaries[-1][1])
+    return boundaries
+
+
+def flux_block_ranges(depth: int = FLUX_DEFAULT_DEPTH,
+                      depth_single: int = FLUX_DEFAULT_DEPTH_SINGLE):
+    """Return ``(double_boundaries, single_boundaries)`` for a FLUX geometry."""
+    return (_stack_boundaries(_DOUBLE_SPLITS, max(int(depth), 0)),
+            _stack_boundaries(_SINGLE_SPLITS, max(int(depth_single), 0)))
+
+
+def _bucket(index: int, boundaries: Sequence[Tuple[int, str]], fallback: str) -> str:
+    for upper, name in boundaries:
+        if index < upper:
+            return name
+    return fallback
+
+
+def classify_flux_key(model_key: str, ranges=None) -> str:
+    """Map a FLUX UNet state-dict key to one of :data:`ALL_FLUX_BLOCKS`."""
+    double_bounds, single_bounds = ranges or flux_block_ranges()
+    nk = normalize_key(model_key)
+
+    match = _RE_SINGLE_BLOCK.search(nk)
+    if match:
+        return _bucket(int(match.group(1)), single_bounds, FLUX_LATE_UP)
+
+    match = _RE_DOUBLE_BLOCK.search(nk)
+    if match:
+        return _bucket(int(match.group(1)), double_bounds, FLUX_CORE)
+
+    for token, block in _FLUX_TOKEN_MAP:
+        if token in nk:
+            return block
+
+    return FLUX_OTHER
+
+
+# -----------------------------------------------------------------------------#
+#                             SDXL  CLASSIFICATION                             #
+# -----------------------------------------------------------------------------#
+
+def classify_sdxl_key(model_key: str) -> str:
+    """Map an SDXL UNet state-dict key to one of :data:`ALL_SDXL_BLOCKS`."""
+    nk = normalize_key(model_key)
+    if "_input_blocks_" in nk:
+        return SDXL_INPUT_BLOCKS
+    if "_middle_block_" in nk:
+        return SDXL_MIDDLE_BLOCK
+    if "_output_blocks_" in nk:
+        return SDXL_OUTPUT_BLOCKS
+    return SDXL_OTHER
+
+
+# -----------------------------------------------------------------------------#
+#                              STRENGTH RESOLUTION                             #
+# -----------------------------------------------------------------------------#
+
+def resolve_block_strengths(family: str,
+                            preset: str,
+                            strength: float,
+                            overrides: Dict[str, float]) -> Dict[str, float]:
+    """Combine the global strength, the preset and the per-block sliders.
+
+    ``Custom`` (and any unknown preset name) uses the slider values; every other
+    preset ignores the sliders and uses its own table, scaled by the preset's
+    own strength multiplier and the node's global strength.
+    """
+    names = ALL_BLOCKS[family]
+    config = LORA_BLOCK_PRESETS[family].get(preset) or {}
+    weights = config.get("block_weights")
+
+    if not weights:
+        return {name: float(overrides.get(name, 1.0)) * float(strength) for name in names}
+
+    base = float(strength) * float(config.get("strength", 1.0))
+    return {name: float(weights.get(name, 1.0)) * base for name in names}

--- a/bobs_lora_loader.py
+++ b/bobs_lora_loader.py
@@ -1,580 +1,331 @@
+"""
+Bobs LoRA Loader — block-weighted LoRA loading for ComfyUI (FLUX + SDXL).
+
+How this works
+--------------
+ComfyUI's ``comfy.lora`` builds a ``key_map`` that translates every LoRA
+exporter dialect (kohya ``lora_unet_*``, OneTrainer ``lora_transformer_*``,
+diffusers ``transformer.*``, lycoris, DiffSynth, ...) into the *canonical model
+state-dict key* the patch targets. ``comfy.lora.load_lora`` then returns a patch
+dict keyed by those canonical names — either a plain string, or a
+``(key, offset)`` tuple when several LoRA tensors are packed into one fused
+weight (FLUX ``qkv``/``linear1``).
+
+We therefore classify patches by their canonical target key rather than by the
+raw name inside the LoRA file. That is dialect-proof: if ComfyUI can load the
+LoRA at all, this node can bucket it.
+"""
+
 import logging
-from typing import Dict, Any, List, Tuple
 import os
-import re
+from typing import Any, Dict, List, Optional, Tuple
 
-import comfy.utils
 import comfy.lora
+import comfy.utils
 import folder_paths
-import torch
-from safetensors.torch import load_file as safe_load_file
 
-# -----------------------------------------------------------------------------#
-#                               BLOCK  CONSTANTS                               #
-# -----------------------------------------------------------------------------#
+from .bobs_blocks import (
+    ALL_FLUX_BLOCKS,
+    ALL_SDXL_BLOCKS,
+    BLOCK_TOOLTIPS,
+    FLUX_DEFAULT_DEPTH,
+    FLUX_DEFAULT_DEPTH_SINGLE,
+    LORA_BLOCK_PRESETS,
+    TEXT_ENCODER_BLOCK,
+    classify_flux_key,
+    classify_sdxl_key,
+    flux_block_ranges,
+    resolve_block_strengths,
+)
 
-# FLUX conceptual blocks. We support BOTH:
-# - model-style module paths: double_blocks.*, single_blocks.*, *_in, final_layer
-# - LoRA-exporter-style keys: lora_transformer_(single_)?transformer_blocks_<n>_*
-FLUX_BLOCK_NAME_MAPPING: Dict[str, List[str]] = {
-    "Text Conditioning": ["txt_in."],
-    "Timestep Embedding": ["time_in."],
-    "Image Hint": ["img_in."],
-    "Guidance Embedding": ["guidance_in."],
-    "Vector Embedding": ["vector_in."],
-    # Down path (model-style tokens)
-    "Early Downsampling (Composition)": [f"double_blocks.{i}." for i in range(0, 4)],
-    "Mid Downsampling (Subject & Concept)": [f"double_blocks.{i}." for i in range(4, 8)],
-    "Late Downsampling (Refinement)": [f"double_blocks.{i}." for i in range(8, 10)],
-    # Core stack (model-style tokens)
-    "Core/Middle Block (Style Focus)": (
-        [f"single_blocks.{i}." for i in range(0, 8)] +
-        [f"double_blocks.{i}." for i in range(10, 19)]
-    ),
-    # Up path (model-style tokens)
-    "Early Upsampling (Initial Style)": [f"double_blocks.{i}." for i in range(19, 23)] +
-                                        [f"single_blocks.{i}." for i in range(8, 16)],
-    "Mid Upsampling (Detail Generation)": [f"double_blocks.{i}." for i in range(23, 27)] +
-                                        [f"single_blocks.{i}." for i in range(16, 32)],
-    "Late Upsampling (Final Textures)": [f"double_blocks.{i}." for i in range(27, 29)] +
-                                        [f"single_blocks.{i}." for i in range(32, 38)],
-    # Output head
-    "Final Output Layer (Latent Projection)": ["final_layer."],
-    "Other Tensors": [],
-}
-ALL_FLUX_BLOCKS = list(FLUX_BLOCK_NAME_MAPPING.keys())
+try:  # Added to ComfyUI in 2025; handles BFL-control / Wan-Fun / USO LoRAs.
+    import comfy.lora_convert as _lora_convert
+except ImportError:  # pragma: no cover - older ComfyUI
+    _lora_convert = None
 
-# SDXL blocks (coarse sliders)
-SDXL_TEXT_ENCODER = "Text Encoder"
-SDXL_INPUT_BLOCKS = "Input Blocks"
-SDXL_MIDDLE_BLOCK = "Middle Block"
-SDXL_OUTPUT_BLOCKS = "Output Blocks"
-ALL_SDXL_BLOCKS = [
-    SDXL_TEXT_ENCODER,
-    SDXL_INPUT_BLOCKS,
-    SDXL_MIDDLE_BLOCK,
-    SDXL_OUTPUT_BLOCKS,
-]
+logger = logging.getLogger("BobsLoraLoader")
 
-# -----------------------------------------------------------------------------#
-#                             PRESET  DEFINITIONS                              #
-# -----------------------------------------------------------------------------#
+MAX_STRENGTH = 5.0
+MAX_BLOCK_WEIGHT = 2.0
 
-LORA_BLOCK_PRESETS = {
-    "FLUX": {
-        "Custom": {},
-        "Full (Normal LoRA)": {
-            "strength": 1.0,
-            "block_weights": {name: 1.0 for name in ALL_FLUX_BLOCKS},
-        },
-        "Character": {
-            "strength": 1.0,
-            "block_weights": {
-                "Text Conditioning": 1.0,
-                "Early Downsampling (Composition)": 0.6,
-                "Mid Downsampling (Subject & Concept)": 1.0,
-                "Late Downsampling (Refinement)": 0.4,
-                "Core/Middle Block (Style Focus)": 1.0,
-                "Early Upsampling (Initial Style)": 0.1,
-                "Mid Upsampling (Detail Generation)": 0.0,
-                "Late Upsampling (Final Textures)": 0.0,
-                "Final Output Layer (Latent Projection)": 0.0,
-            },
-        },
-        "Style": {
-            "strength": 1.0,
-            "block_weights": {
-                "Text Conditioning": 0.2,
-                "Early Downsampling (Composition)": 0.1,
-                "Mid Downsampling (Subject & Concept)": 0.0,
-                "Late Downsampling (Refinement)": 0.2,
-                "Core/Middle Block (Style Focus)": 0.5,
-                "Early Upsampling (Initial Style)": 1.0,
-                "Mid Upsampling (Detail Generation)": 1.0,
-                "Late Upsampling (Final Textures)": 1.0,
-                "Final Output Layer (Latent Projection)": 1.0,
-            },
-        },
-        "Concept": {
-            "strength": 1.0,
-            "block_weights": {
-                "Text Conditioning": 1.0,
-                "Early Downsampling (Composition)": 1.0,
-                "Mid Downsampling (Subject & Concept)": 0.9,
-                "Late Downsampling (Refinement)": 0.6,
-                "Core/Middle Block (Style Focus)": 0.7,
-                "Early Upsampling (Initial Style)": 0.5,
-                "Mid Upsampling (Detail Generation)": 0.3,
-                "Late Upsampling (Final Textures)": 0.1,
-                "Final Output Layer (Latent Projection)": 0.0,
-            },
-        },
-        "Fix Hands/Anatomy": {
-            "strength": 0.4,
-            "block_weights": {
-                "Text Conditioning": 0.2,
-                "Early Downsampling (Composition)": 1.0,
-                "Mid Downsampling (Subject & Concept)": 0.3,
-                "Late Downsampling (Refinement)": 0.0,
-                "Core/Middle Block (Style Focus)": 0.0,
-                "Early Upsampling (Initial Style)": 0.0,
-                "Mid Upsampling (Detail Generation)": 0.0,
-                "Late Upsampling (Final Textures)": 0.0,
-                "Final Output Layer (Latent Projection)": 0.0,
-            },
-        },
-    },
-
-    "SDXL": {
-        "Custom": {},
-        "Full (Normal LoRA)": {
-            "strength": 1.0,
-            "block_weights": {b: 1.0 for b in ALL_SDXL_BLOCKS},
-        },
-        "Character": {
-            "strength": 1.0,
-            "block_weights": {
-                SDXL_TEXT_ENCODER: 1.0,
-                SDXL_INPUT_BLOCKS: 1.0,
-                SDXL_MIDDLE_BLOCK: 1.0,
-                SDXL_OUTPUT_BLOCKS: 0.2,
-            },
-        },
-        "Style": {
-            "strength": 1.0,
-            "block_weights": {
-                SDXL_TEXT_ENCODER: 0.0,
-                SDXL_INPUT_BLOCKS: 0.2,
-                SDXL_MIDDLE_BLOCK: 0.5,
-                SDXL_OUTPUT_BLOCKS: 1.0,
-            },
-        },
-        "Concept": {
-            "strength": 1.0,
-            "block_weights": {
-                SDXL_TEXT_ENCODER: 1.0,
-                SDXL_INPUT_BLOCKS: 0.8,
-                SDXL_MIDDLE_BLOCK: 0.7,
-                SDXL_OUTPUT_BLOCKS: 0.5,
-            },
-        },
-        "Fix Hands/Anatomy": {
-            "strength": 0.4,
-            "block_weights": {
-                SDXL_TEXT_ENCODER: 0.2,
-                SDXL_INPUT_BLOCKS: 1.0,
-                SDXL_MIDDLE_BLOCK: 0.4,
-                SDXL_OUTPUT_BLOCKS: 0.0,
-            },
-        },
-    },
-}
 
 # -----------------------------------------------------------------------------#
 #                               HELPER FUNCTIONS                               #
 # -----------------------------------------------------------------------------#
 
-def _build_key_map(model, clip) -> Dict[str, Any]:
-    """Build key_map compatibly across ComfyUI versions."""
-    key_map: Dict[str, Any] = {}
-    if hasattr(comfy.lora, "model_lora_keys_unet"):
-        comfy.lora.model_lora_keys_unet(model.model, key_map)
-    if hasattr(comfy.lora, "model_lora_keys_clip"):
-        comfy.lora.model_lora_keys_clip(clip.cond_stage_model, key_map)
-    return key_map
+def _patch_target(patch_key: Any) -> str:
+    """Return the model state-dict key a patch entry targets.
 
-def _invert_key_map(key_map: Dict[str, Any]) -> Dict[Any, str]:
-    """Invert key_map from raw_name -> (module, ...) to (module) -> raw_name."""
-    inv: Dict[Any, str] = {}
-    for raw, info in key_map.items():
-        inv[info[0]] = raw  # info[0] is the nn.Module
-    return inv
-
-def _example_raws_from_patches(patches: Dict[Tuple[Any, ...], Any],
-                               inv_key_map: Dict[Any, str],
-                               limit: int = 3) -> List[str]:
-    out: List[str] = []
-    for key_tuple in patches.keys():
-        mod = key_tuple[0]
-        raw = inv_key_map.get(mod, "")
-        if raw:
-            out.append(raw.split(".", 1)[-1])
-        if len(out) >= limit:
-            break
-    return out
-
-# ----------------------------- SDXL grouping -------------------------------- #
-
-def _split_sdxl_patches_by_block(loaded_patches: Dict[Any, Any],
-                                 inv_key_map: Dict[Any, str],
-                                 logger: logging.Logger):
-    """Split patches into SDXL input/middle/output/clip groups based on raw weight names."""
-    p_in, p_mid, p_out, p_clip, p_other = {}, {}, {}, {}, {}
-    for key_tuple, patch in loaded_patches.items():
-        raw_key = inv_key_map.get(key_tuple[0], "")
-        rk = raw_key  # permissive contains-checks handle exporter differences
-        
-        # --- MODIFIED SECTION ---
-        # Catch `unet.`-prefixed keys and assign them to Input Blocks
-        if "input_blocks" in rk or "unet." in rk:
-            p_in[key_tuple] = patch
-        # --- END MODIFICATION ---
-
-        elif "middle_block" in rk:
-            p_mid[key_tuple] = patch
-        elif "output_blocks" in rk:
-            p_out[key_tuple] = patch
-        elif ("text_encoder" in rk) or ("lora_te" in rk) or ("clip" in rk and "proj" in rk):
-            p_clip[key_tuple] = patch
-        else:
-            p_other[key_tuple] = patch
-            # Leave diagnostic logger in place for future troubleshooting
-            if raw_key:
-                logger.warning(f"[SDXL Diagnostics] Unclassified key: {raw_key}")
-    return p_in, p_mid, p_out, p_clip, p_other
-
-def _log_sdxl_counts(logger: logging.Logger,
-                     p_in: Dict[Any, Any], p_mid: Dict[Any, Any],
-                     p_out: Dict[Any, Any], p_clip: Dict[Any, Any],
-                     p_other: Dict[Any, Any],
-                     te_strength: float, in_strength: float,
-                     mid_strength: float, out_strength: float,
-                     inv_key_map: Dict[Any, str]):
-    cnt_te = len(p_clip)
-    cnt_in = len(p_in)
-    cnt_mid = len(p_mid)
-    cnt_out = len(p_out)
-    cnt_other = len(p_other)
-    logger.info(
-        f"[SDXL] Patch counts — TE:{cnt_te} IN:{cnt_in} MID:{cnt_mid} OUT:{cnt_out} OTHER:{cnt_other} "
-        f"| strengths TE={te_strength:.2f} IN={in_strength:.2f} MID={mid_strength:.2f} OUT={out_strength:.2f}"
-    )
-
-    def _why_zero(name: str, cnt: int, strength: float, sample_from: Dict[Any, Any]):
-        if cnt > 0:
-            return
-        if strength == 0.0:
-            logger.info(f"[SDXL] {name}: 0 patches applied because strength is 0.00.")
-        else:
-            examples = _example_raws_from_patches(sample_from, inv_key_map, 3)
-            logger.info(
-                f"[SDXL] {name}: 0 patches found in this LoRA (strength {strength:.2f} > 0). "
-                f"Likely the LoRA was trained without deltas for this block.\n"
-                f"Counts — TE:{cnt_te} IN:{cnt_in} MID:{cnt_mid} OUT:{cnt_out} OTHER:{cnt_other}. "
-                f"Example raw tails present: {examples}"
-            )
-
-    sample_source = {}
-    for d in (p_in, p_mid, p_out, p_clip, p_other):
-        if len(d) > len(sample_source):
-            sample_source = d
-
-    _why_zero("Input Blocks", cnt_in, in_strength, sample_source)
-    _why_zero("Middle Block", cnt_mid, mid_strength, sample_source)
-    _why_zero("Output Blocks", cnt_out, out_strength, sample_source)
-
-# ----------------------------- FLUX grouping -------------------------------- #
-
-# Normalize keys to underscore style, then regex them.
-def _normalize_key(key: str) -> str:
-    """Lowercase and replace separators with underscores for uniform matching."""
-    k = key.replace("/", "_").replace(".", "_").replace(":", "_").lower()
-    k = re.sub(r"__+", "_", k)
-    return k
-
-# Heuristic splitter for Flux exporter keys (plus model-style).
-# Matches variations like:
-#   transformer_blocks_<IDX>_...
-#   lora_transformer_transformer_blocks_<IDX>_...
-#   single_transformer_blocks_<IDX>_...
-#   lora_transformer_single_transformer_blocks_<IDX>_...
-# And also model-style paths like:
-#   double_blocks.<i>.
-#   single_blocks.<i>.
-_RE_TX_BLOCK_US = re.compile(r"(?:^|_)(?:lora_transformer_)?transformer_blocks_(\d+)(?:_|$)")
-_RE_SINGLE_TX_BLOCK_US = re.compile(r"(?:^|_)(?:lora_transformer_)?single_transformer_blocks_(\d+)(?:_|$)")
-_RE_DOUBLE_BLOCKS_US = re.compile(r"(?:^|_)(?:lora_transformer_)?double_blocks_(\d+)(?:_|$)")
-_RE_SINGLE_BLOCKS_US = re.compile(r"(?:^|_)(?:lora_transformer_)?single_blocks_(\d+)(?:_|$)")
-
-def _flux_concept_from_raw(raw_key: str) -> str:
+    ``load_lora`` keys are either the key itself or ``(key, offset)`` for
+    patches into a slice of a fused weight — the same shape ``ModelPatcher.
+    add_patches`` unpacks.
     """
-    Map a raw module key to a conceptual FLUX block. Supports both:
-      - model-style paths (double_blocks.*, single_blocks.*, *_in, final_layer)
-      - LoRA-exporter-style names (transformer_blocks_#, single_transformer_blocks_#)
+    return patch_key if isinstance(patch_key, str) else patch_key[0]
+
+
+def _build_key_maps(model, clip) -> Tuple[Dict[str, Any], set]:
+    """Build ComfyUI's LoRA key map and the set of keys owned by the UNet.
+
+    Returning the UNet key set is what lets us route text-encoder patches to the
+    CLIP patcher and everything else to the model patcher without guessing from
+    key names.
     """
-    rk_norm = _normalize_key(raw_key)
+    unet_map: Dict[str, Any] = {}
+    clip_map: Dict[str, Any] = {}
 
-    # Inlet/head tokens (string contains checks on normalized)
-    if "_txt_in" in rk_norm or "time_text_embed" in rk_norm: return "Text Conditioning"
-    if "_time_in" in rk_norm: return "Timestep Embedding"
-    if "_img_in" in rk_norm: return "Image Hint"
-    if "_guidance_in" in rk_norm: return "Guidance Embedding"
-    if "_vector_in" in rk_norm: return "Vector Embedding"
-    if "_final_layer" in rk_norm: return "Final Output Layer (Latent Projection)"
+    if model is not None and hasattr(comfy.lora, "model_lora_keys_unet"):
+        comfy.lora.model_lora_keys_unet(model.model, unet_map)
+    if clip is not None and hasattr(comfy.lora, "model_lora_keys_clip"):
+        comfy.lora.model_lora_keys_clip(clip.cond_stage_model, clip_map)
 
-    # LoRA-exporter: single_transformer_blocks_*
-    m_single_tx = _RE_SINGLE_TX_BLOCK_US.search(rk_norm)
-    if m_single_tx:
-        idx = int(m_single_tx.group(1))
-        if 0 <= idx < 8: return "Core/Middle Block (Style Focus)"
-        if 8 <= idx < 16: return "Early Upsampling (Initial Style)"
-        if 16 <= idx < 32: return "Mid Upsampling (Detail Generation)"
-        if 32 <= idx < 38: return "Late Upsampling (Final Textures)"
+    key_map = dict(clip_map)
+    key_map.update(unet_map)  # UNet wins on the (unlikely) collision
+    unet_targets = {_patch_target(v) for v in unet_map.values()}
+    return key_map, unet_targets
 
-    # Model-style single_blocks
-    m_sb = _RE_SINGLE_BLOCKS_US.search(rk_norm)
-    if m_sb:
-        idx = int(m_sb.group(1))
-        if 0 <= idx < 8: return "Core/Middle Block (Style Focus)"
-        if 8 <= idx < 16: return "Early Upsampling (Initial Style)"
-        if 16 <= idx < 32: return "Mid Upsampling (Detail Generation)"
-        if 32 <= idx < 38: return "Late Upsampling (Final Textures)"
 
-    # Model-style double_blocks indices
-    m_db = _RE_DOUBLE_BLOCKS_US.search(rk_norm)
-    if m_db:
-        idx = int(m_db.group(1))
-        if 0 <= idx < 4:  return "Early Downsampling (Composition)"
-        if 4 <= idx < 8:  return "Mid Downsampling (Subject & Concept)"
-        if 8 <= idx < 10:  return "Late Downsampling (Refinement)"
-        if 10 <= idx < 19: return "Core/Middle Block (Style Focus)"
-        if 19 <= idx < 23: return "Early Upsampling (Initial Style)"
-        if 23 <= idx < 27: return "Mid Upsampling (Detail Generation)"
-        if 27 <= idx < 29: return "Late Upsampling (Final Textures)"
+def _flux_geometry(model) -> Tuple[int, int]:
+    """Read the double/single stream depths off the loaded FLUX model."""
+    try:
+        config = model.model.model_config.unet_config
+        depth = int(config.get("depth", 0)) or FLUX_DEFAULT_DEPTH
+        depth_single = int(config.get("depth_single_blocks", 0)) or FLUX_DEFAULT_DEPTH_SINGLE
+        return depth, depth_single
+    except Exception:  # noqa: BLE001 - any unexpected config shape falls back
+        return FLUX_DEFAULT_DEPTH, FLUX_DEFAULT_DEPTH_SINGLE
 
-    # LoRA-exporter: transformer_blocks_IDX => map ranges (double path)
-    m_tx = _RE_TX_BLOCK_US.search(rk_norm)
-    if m_tx:
-        idx = int(m_tx.group(1))
-        if 0 <= idx < 4:  return "Early Downsampling (Composition)"
-        if 4 <= idx < 8:  return "Mid Downsampling (Subject & Concept)"
-        if 8 <= idx < 10:  return "Late Downsampling (Refinement)"
-        if 10 <= idx < 19: return "Core/Middle Block (Style Focus)"
-        if 19 <= idx < 23: return "Early Upsampling (Initial Style)"
-        if 23 <= idx < 27: return "Mid Upsampling (Detail Generation)"
-        if 27 <= idx < 29: return "Late Upsampling (Final Textures)"
 
-    return "Other Tensors"
+def _format_report(tag: str,
+                   lora_name: str,
+                   preset: str,
+                   blocks: List[str],
+                   grouped: Dict[str, Dict[Any, Any]],
+                   strengths: Dict[str, float],
+                   applied: Dict[str, int]) -> str:
+    lines = [f"[{tag}] {lora_name}  (preset: {preset})",
+             f"{'block':<40} {'weight':>7} {'found':>7} {'applied':>8}"]
+    for name in blocks:
+        lines.append(
+            f"{name:<40} {strengths.get(name, 0.0):>7.2f} "
+            f"{len(grouped.get(name, {})):>7} {applied.get(name, 0):>8}"
+        )
+    total_found = sum(len(g) for g in grouped.values())
+    total_applied = sum(applied.values())
+    lines.append(f"{'TOTAL':<40} {'':>7} {total_found:>7} {total_applied:>8}")
+    return "\n".join(lines)
 
-def _group_flux_patches(loaded_patches: Dict[Any, Any],
-                        inv_key_map: Dict[Any, str]) -> Dict[str, Dict[Any, Any]]:
-    groups = {name: {} for name in ALL_FLUX_BLOCKS}
-    for key_tuple, patch in loaded_patches.items():
-        raw_key = inv_key_map.get(key_tuple[0], "")
-        concept = _flux_concept_from_raw(raw_key) if raw_key else "Other Tensors"
-        if concept in groups:
-            groups[concept][key_tuple] = patch
-        else:
-            groups["Other Tensors"][key_tuple] = patch
-    return groups
 
-def _log_flux_counts(logger: logging.Logger,
-                     groups: Dict[str, Dict[Any, Any]],
-                     strengths: Dict[str, float],
-                     inv_key_map: Dict[Any, str]):
-    logger.info("[FLUX] Patch counts per block:")
-    total = 0
-    for name in ALL_FLUX_BLOCKS:
-        cnt = len(groups.get(name, {}))
-        total += cnt
-        logger.info(f"    - {name}: {cnt} (strength {strengths.get(name, 0.0):.2f})")
-    logger.info(f"[FLUX] Total matched patches: {total}")
-    
-    # Explain zeros
-    for name in ALL_FLUX_BLOCKS:
-        patches = groups.get(name, {})
-        strength = strengths.get(name, 0.0)
-        if len(patches) > 0:
+def _explain_empty_blocks(tag: str,
+                          blocks: List[str],
+                          grouped: Dict[str, Dict[Any, Any]],
+                          strengths: Dict[str, float]) -> None:
+    """Log why a block with a non-zero weight contributed nothing."""
+    for name in blocks:
+        if grouped.get(name) or strengths.get(name, 0.0) == 0.0:
             continue
+        logger.info(
+            "[%s] %s: weight %.2f but this LoRA contains no tensors for that block.",
+            tag, name, strengths[name],
+        )
+
+
+# -----------------------------------------------------------------------------#
+#                                 SHARED  NODE                                 #
+# -----------------------------------------------------------------------------#
+
+class _BobsLoraLoaderBase:
+    """Shared load / classify / patch pipeline for the FLUX and SDXL loaders."""
+
+    FAMILY = "FLUX"
+    BLOCKS: List[str] = ALL_FLUX_BLOCKS
+
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING")
+    RETURN_NAMES = ("MODEL", "CLIP", "info")
+    OUTPUT_TOOLTIPS = (
+        "Model with the block-weighted LoRA applied.",
+        "CLIP with the text-encoder portion of the LoRA applied.",
+        "Per-block report: weight, tensors found and tensors actually patched.",
+    )
+    FUNCTION = "apply_lora"
+    CATEGORY = "Bobs_Nodes"
+
+    def __init__(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self._cache_key: Optional[tuple] = None
+        self._cache_sd: Optional[Dict[str, Any]] = None
+
+    # ---------------------------------------------------------------- inputs --
+
+    @classmethod
+    def _input_types(cls) -> Dict[str, Any]:
+        required = {
+            "model": ("MODEL", {"tooltip": "Diffusion model to patch."}),
+            "lora_name": (
+                ["None"] + folder_paths.get_filename_list("loras"),
+                {"tooltip": "LoRA file to load. 'None' passes the model through untouched."},
+            ),
+            "strength": ("FLOAT", {
+                "default": 1.0, "min": -MAX_STRENGTH, "max": MAX_STRENGTH, "step": 0.01,
+                "tooltip": "Global multiplier applied on top of every block weight.",
+            }),
+            "preset": (
+                list(LORA_BLOCK_PRESETS[cls.FAMILY].keys()),
+                {"tooltip": "Choose 'Custom' to use the sliders below; any other preset overrides them."},
+            ),
+        }
+        for block in cls.BLOCKS:
+            required[block] = ("FLOAT", {
+                "default": 1.0, "min": -MAX_BLOCK_WEIGHT, "max": MAX_BLOCK_WEIGHT, "step": 0.05,
+                "tooltip": BLOCK_TOOLTIPS.get(block, block),
+            })
+        return {
+            "required": required,
+            "optional": {
+                "clip": ("CLIP", {"tooltip": "Optional. Leave unconnected to patch the model only."}),
+            },
+        }
+
+    # ------------------------------------------------------------ lora  file --
+
+    def _load_lora_state_dict(self, lora_path: str) -> Dict[str, Any]:
+        """Load a LoRA, reusing the previous load when the file is unchanged."""
+        try:
+            stat = os.stat(lora_path)
+            cache_key = (lora_path, stat.st_mtime_ns, stat.st_size)
+        except OSError:
+            cache_key = None
+
+        if cache_key is not None and cache_key == self._cache_key:
+            return self._cache_sd
+
+        # load_torch_file handles .safetensors and pickled checkpoints, and
+        # applies weights_only=True to the latter.
+        state_dict = comfy.utils.load_torch_file(lora_path, safe_load=True)
+        if _lora_convert is not None:
+            state_dict = _lora_convert.convert_lora(state_dict)
+
+        self._cache_key, self._cache_sd = cache_key, state_dict
+        return state_dict
+
+    # ------------------------------------------------------------ classifier --
+
+    def _classifier(self, model):
+        """Return ``fn(model_state_dict_key) -> block name`` for this family."""
+        raise NotImplementedError
+
+    # ----------------------------------------------------------------- apply --
+
+    def apply_lora(self, model, lora_name, strength, preset, clip=None, **kwargs):
+        tag = self.FAMILY
+
+        if lora_name in (None, "", "None"):
+            return (model, clip, f"[{tag}] no LoRA selected.")
         if strength == 0.0:
-            logger.info(f"[FLUX] {name}: 0 patches applied because strength is 0.00.")
-        else:
-            # Use the largest non-empty group as a sample source
-            non_empty = [(k, v) for k, v in groups.items() if len(v) > 0]
-            sample = non_empty[0][1] if non_empty else {}
-            examples = _example_raws_from_patches(sample, inv_key_map, 3)
-            logger.info(
-                f"[FLUX] {name}: 0 patches in this LoRA (strength {strength:.2f} > 0). "
-                f"LoRA likely doesn't include weights for this block. "
-                f"Sample mapped raw tails: {examples}"
-            )
-            
+            return (model, clip, f"[{tag}] {lora_name}: strength is 0.00, nothing applied.")
+
+        lora_path = folder_paths.get_full_path("loras", lora_name)
+        if not lora_path:
+            message = f"[{tag}] LoRA file not found: {lora_name}"
+            self.logger.error(message)
+            return (model, clip, message)
+
+        try:
+            lora_sd = self._load_lora_state_dict(lora_path)
+        except Exception as exc:  # noqa: BLE001 - surface, never crash the graph
+            message = f"[{tag}] failed to read {lora_name}: {exc}"
+            self.logger.error(message)
+            return (model, clip, message)
+
+        strengths = resolve_block_strengths(self.FAMILY, preset, strength, kwargs)
+
+        key_map, unet_targets = _build_key_maps(model, clip)
+        if not key_map:
+            message = f"[{tag}] could not build a key map for this model; LoRA not applied."
+            self.logger.warning(message)
+            return (model, clip, message)
+
+        all_patches = comfy.lora.load_lora(lora_sd, key_map)
+        if not all_patches:
+            message = (f"[{tag}] {lora_name}: none of its tensors match this model. "
+                       f"Is it a LoRA for a different architecture?")
+            self.logger.warning(message)
+            return (model, clip, message)
+
+        # Group UNet patches per conceptual block; CLIP patches all share the
+        # text-encoder block.
+        classify = self._classifier(model)
+        text_encoder_block = TEXT_ENCODER_BLOCK[self.FAMILY]
+        grouped: Dict[str, Dict[Any, Any]] = {name: {} for name in self.BLOCKS}
+
+        for patch_key, patch in all_patches.items():
+            target = _patch_target(patch_key)
+            block = classify(target) if target in unet_targets else text_encoder_block
+            grouped[block][patch_key] = patch
+
+        out_model = model.clone() if model is not None else None
+        out_clip = clip.clone() if clip is not None else None
+
+        applied: Dict[str, int] = {}
+        for name in self.BLOCKS:
+            patches = grouped[name]
+            block_strength = strengths.get(name, 0.0)
+            patcher = out_clip if name == text_encoder_block else out_model
+            if not patches or block_strength == 0.0 or patcher is None:
+                applied[name] = 0
+                continue
+            applied[name] = len(patcher.add_patches(patches, block_strength))
+
+        # Any tensor in the file that ComfyUI could not place is reported by
+        # comfy.lora.load_lora itself as a "lora key not loaded" warning.
+        report = _format_report(tag, lora_name, preset, self.BLOCKS,
+                                grouped, strengths, applied)
+        self.logger.info("\n%s", report)
+        _explain_empty_blocks(tag, self.BLOCKS, grouped, strengths)
+
+        return (out_model, out_clip, report)
+
+
 # -----------------------------------------------------------------------------#
 #                               FLUX  LOADER                                   #
 # -----------------------------------------------------------------------------#
 
-class BobsLoraLoaderFlux:
-    def __init__(self):
-        self.logger = logging.getLogger(self.__class__.__name__)
+class BobsLoraLoaderFlux(_BobsLoraLoaderBase):
+    FAMILY = "FLUX"
+    BLOCKS = ALL_FLUX_BLOCKS
+    DESCRIPTION = (
+        "Applies a LoRA to a FLUX model with an independent weight per conceptual "
+        "block (composition, subject, style core, detail, texture, text encoder). "
+        "Block ranges are derived from the loaded model's own depth, so FLUX.1 "
+        "dev/schnell and pruned variants are all handled."
+    )
 
     @classmethod
     def INPUT_TYPES(cls):
-        req = {
-            "model": ("MODEL",),
-            "clip": ("CLIP",),
-            "lora_name": (["None"] + folder_paths.get_filename_list("loras"),),
-            "strength": ("FLOAT", {"default": 1.0, "min": -5.0, "max": 5.0, "step": 0.01}),
-            "preset": (list(LORA_BLOCK_PRESETS["FLUX"].keys()),),
-        }
-        for blk in ALL_FLUX_BLOCKS:
-            req[blk] = ("FLOAT", {"default": 1.0, "min": -2.0, "max": 2.0, "step": 0.05})
-        return {"required": req}
+        return cls._input_types()
 
-    RETURN_TYPES = ("MODEL", "CLIP")
-    FUNCTION = "apply_lora"
-    CATEGORY = "Bobs_Nodes"
-
-    def apply_lora(self, model, clip, lora_name, strength, preset, **kwargs):
-
-        if lora_name == "None" or strength == 0.0:
-            return model, clip
-
-        lora_path = folder_paths.get_full_path("loras", lora_name)
-        if not lora_path:
-            self.logger.error(f"[FLUX] LoRA file not found: {lora_name}")
-            return model, clip
-
-        self.logger.info(f"[FLUX] Loading LoRA: {lora_name}")
-        if os.path.splitext(lora_path)[1].lower() == ".safetensors":
-            lora_sd = safe_load_file(lora_path, device="cpu")
-        else:
-            lora_sd = torch.load(lora_path, map_location="cpu")
-
-        # -------- build per-block final strengths ----------
-        block_strength: Dict[str, float] = {}
-        if preset == "Custom":
-            for blk in ALL_FLUX_BLOCKS:
-                block_strength[blk] = float(kwargs.get(blk, 1.0)) * float(strength)
-        else:
-            cfg = LORA_BLOCK_PRESETS["FLUX"][preset]
-            base = float(strength) * float(cfg.get("strength", 1.0))
-            weights = cfg.get("block_weights", {})
-            for blk in ALL_FLUX_BLOCKS:
-                block_strength[blk] = float(weights.get(blk, 1.0)) * base
-
-        # -------- build key map & load patches -------------
-        key_map: Dict[str, Any] = _build_key_map(model, clip)
-        if not key_map:
-            self.logger.warning("[FLUX] Empty key_map; LoRA will not be applied.")
-            return model, clip
-
-        inv_key_map = _invert_key_map(key_map)
-        all_patches = comfy.lora.load_lora(lora_sd, key_map)
-
-        if not all_patches:
-            self.logger.warning("[FLUX] No matching keys in LoRA checkpoint.")
-            return model, clip
-
-        grouped_patches = _group_flux_patches(all_patches, inv_key_map)
-
-        # -------- logging: counts & explanations -----------
-        _log_flux_counts(self.logger, grouped_patches, block_strength, inv_key_map)
-
-        # -------- clone & attach patches group by group ----
-        out_model = model.clone()
-        out_clip = clip.clone()
-
-        for concept, patches_in_group in grouped_patches.items():
-            s = block_strength.get(concept, 0.0)
-            if s == 0.0 or not patches_in_group:
-                continue
-            # Apply to both model and clip; non-matching targets are no-ops
-            out_model.add_patches(patches_in_group, s)
-            out_clip.add_patches(patches_in_group, s)
-
-        return out_model, out_clip
+    def _classifier(self, model):
+        ranges = flux_block_ranges(*_flux_geometry(model))
+        return lambda key: classify_flux_key(key, ranges)
 
 
 # -----------------------------------------------------------------------------#
 #                               SDXL  LOADER                                   #
 # -----------------------------------------------------------------------------#
 
-class BobsLoraLoaderSdxl:
-    def __init__(self):
-        self.logger = logging.getLogger(self.__class__.__name__)
+class BobsLoraLoaderSdxl(_BobsLoraLoaderBase):
+    FAMILY = "SDXL"
+    BLOCKS = ALL_SDXL_BLOCKS
+    DESCRIPTION = (
+        "Applies a LoRA to an SDXL model with independent weights for the text "
+        "encoder and the UNet input / middle / output stages."
+    )
 
     @classmethod
     def INPUT_TYPES(cls):
-        req = {
-            "model": ("MODEL",),
-            "clip": ("CLIP",),
-            "lora_name": (["None"] + folder_paths.get_filename_list("loras"),),
-            "strength": ("FLOAT", {"default": 1.0, "min": -5.0, "max": 5.0, "step": 0.01}),
-            "preset": (list(LORA_BLOCK_PRESETS["SDXL"].keys()),),
-        }
-        for blk in ALL_SDXL_BLOCKS:
-            req[blk] = ("FLOAT", {"default": 1.0, "min": -2.0, "max": 2.0, "step": 0.05})
-        return {"required": req}
+        return cls._input_types()
 
-    RETURN_TYPES = ("MODEL", "CLIP")
-    FUNCTION = "apply_lora"
-    CATEGORY = "Bobs_Nodes"
-
-    def apply_lora(self, model, clip, lora_name, strength, preset, **kwargs):
-
-        if lora_name == "None" or strength == 0.0:
-            return model, clip
-
-        lora_path = folder_paths.get_full_path("loras", lora_name)
-        if not lora_path:
-            self.logger.error(f"[SDXL] LoRA file not found: {lora_name}")
-            return model, clip
-
-        self.logger.info(f"[SDXL] Loading LoRA: {lora_name}")
-        if os.path.splitext(lora_path)[1].lower() == ".safetensors":
-            lora_sd = safe_load_file(lora_path, device="cpu")
-        else:
-            lora_sd = torch.load(lora_path, map_location="cpu")
-
-        # --- Build block strengths ---
-        if preset == "Custom":
-            te_strength = float(kwargs.get(SDXL_TEXT_ENCODER, 1.0)) * float(strength)
-            in_strength = float(kwargs.get(SDXL_INPUT_BLOCKS, 1.0)) * float(strength)
-            mid_strength = float(kwargs.get(SDXL_MIDDLE_BLOCK, 1.0)) * float(strength)
-            out_strength = float(kwargs.get(SDXL_OUTPUT_BLOCKS, 1.0)) * float(strength)
-        else:
-            cfg = LORA_BLOCK_PRESETS["SDXL"][preset]
-            base = float(strength) * float(cfg.get("strength", 1.0))
-            weights = cfg.get("block_weights", {})
-            te_strength  = float(weights.get(SDXL_TEXT_ENCODER, 1.0)) * base
-            in_strength  = float(weights.get(SDXL_INPUT_BLOCKS, 1.0)) * base
-            mid_strength = float(weights.get(SDXL_MIDDLE_BLOCK, 1.0)) * base
-            out_strength = float(weights.get(SDXL_OUTPUT_BLOCKS, 1.0)) * base
-
-        # --- Build key map for model and clip ---
-        key_map: Dict[str, Any] = _build_key_map(model, clip)
-        if not key_map:
-            self.logger.warning("[SDXL] Empty key_map; LoRA will not be applied.")
-            return model, clip
-
-        inv_key_map = _invert_key_map(key_map)
-        all_patches = comfy.lora.load_lora(lora_sd, key_map)
-
-        if not all_patches:
-            self.logger.warning("[SDXL] No matching keys in LoRA checkpoint.")
-            return model, clip
-
-        p_in, p_mid, p_out, p_clip, p_other = _split_sdxl_patches_by_block(all_patches, inv_key_map, self.logger)
-
-        # --- Log counts and zero reasons ---
-        _log_sdxl_counts(self.logger, p_in, p_mid, p_out, p_clip, p_other,
-                         te_strength, in_strength, mid_strength, out_strength,
-                         inv_key_map)
-
-        # --- Apply ---
-        out_model = model.clone()
-        out_clip = clip.clone()
-
-        if p_in and in_strength != 0.0:
-            out_model.add_patches(p_in, in_strength)
-        if p_mid and mid_strength != 0.0:
-            out_model.add_patches(p_mid, mid_strength)
-        if p_out and out_strength != 0.0:
-            out_model.add_patches(p_out, out_strength)
-        if p_clip and te_strength != 0.0:
-            out_clip.add_patches(p_clip, te_strength)
-
-        return (out_model, out_clip)
+    def _classifier(self, model):
+        return classify_sdxl_key
 
 
 # -----------------------------------------------------------------------------#

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Bobs_LoRA_Loader"
 description = "A custom LoRA loader node for ComfyUI with advanced block-weighting controls for both SDXL and FLUX models. Features presets for common use-cases like 'Character' and 'Style', and a 'Custom' mode for fine-grained control over individual model blocks."
-version = "1.0.6"
+version = "1.1.0"
 license = {file = "LICENSE"}
 
 [project.urls]

--- a/tests/test_bobs_blocks.py
+++ b/tests/test_bobs_blocks.py
@@ -1,0 +1,288 @@
+"""Unit tests for the block-classification logic.
+
+These run without ComfyUI or torch installed:
+
+    python -m unittest discover -s tests -v
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from bobs_blocks import (  # noqa: E402
+    ALL_FLUX_BLOCKS,
+    ALL_SDXL_BLOCKS,
+    FLUX_CORE,
+    FLUX_DEFAULT_DEPTH,
+    FLUX_DEFAULT_DEPTH_SINGLE,
+    FLUX_EARLY_DOWN,
+    FLUX_EARLY_UP,
+    FLUX_FINAL,
+    FLUX_GUIDANCE,
+    FLUX_IMAGE_HINT,
+    FLUX_LATE_DOWN,
+    FLUX_LATE_UP,
+    FLUX_MID_DOWN,
+    FLUX_MID_UP,
+    FLUX_OTHER,
+    FLUX_TEXT_CONDITIONING,
+    FLUX_TEXT_ENCODER,
+    FLUX_TIMESTEP,
+    FLUX_VECTOR,
+    LORA_BLOCK_PRESETS,
+    SDXL_INPUT_BLOCKS,
+    SDXL_MIDDLE_BLOCK,
+    SDXL_OTHER,
+    SDXL_OUTPUT_BLOCKS,
+    SDXL_TEXT_ENCODER,
+    classify_flux_key,
+    classify_sdxl_key,
+    flux_block_ranges,
+    normalize_key,
+    resolve_block_strengths,
+)
+
+
+class TestNormalizeKey(unittest.TestCase):
+    def test_separators_collapse_to_underscores(self):
+        self.assertEqual(
+            normalize_key("diffusion_model.double_blocks.3.img_attn.qkv.weight"),
+            "_diffusion_model_double_blocks_3_img_attn_qkv_weight",
+        )
+
+    def test_leading_underscore_is_always_present(self):
+        self.assertTrue(normalize_key("txt_in.weight").startswith("_txt_in"))
+        self.assertTrue(normalize_key("_already").startswith("_already"))
+
+    def test_runs_of_separators_collapse(self):
+        self.assertEqual(normalize_key("a..b//c"), "_a_b_c")
+
+
+class TestFluxRanges(unittest.TestCase):
+    def test_canonical_geometry_reproduces_documented_ranges(self):
+        double, single = flux_block_ranges(FLUX_DEFAULT_DEPTH, FLUX_DEFAULT_DEPTH_SINGLE)
+        self.assertEqual(double, [(4, FLUX_EARLY_DOWN), (8, FLUX_MID_DOWN),
+                                  (10, FLUX_LATE_DOWN), (19, FLUX_CORE)])
+        self.assertEqual(single, [(8, FLUX_CORE), (16, FLUX_EARLY_UP),
+                                  (32, FLUX_MID_UP), (38, FLUX_LATE_UP)])
+
+    def test_boundaries_are_monotonic_and_cover_the_stack(self):
+        for depth in range(0, 60):
+            double, single = flux_block_ranges(depth, depth)
+            for bounds in (double, single):
+                uppers = [u for u, _ in bounds]
+                self.assertEqual(uppers, sorted(uppers), f"depth={depth}")
+                self.assertEqual(uppers[-1], depth, f"depth={depth}")
+
+    def test_every_index_of_a_nonstandard_depth_is_classified(self):
+        ranges = flux_block_ranges(8, 16)
+        for i in range(8):
+            key = f"diffusion_model.double_blocks.{i}.img_attn.qkv.weight"
+            self.assertIn(classify_flux_key(key, ranges), ALL_FLUX_BLOCKS)
+            self.assertNotEqual(classify_flux_key(key, ranges), FLUX_OTHER)
+        for i in range(16):
+            key = f"diffusion_model.single_blocks.{i}.linear1.weight"
+            self.assertNotEqual(classify_flux_key(key, ranges), FLUX_OTHER)
+
+
+class TestFluxClassification(unittest.TestCase):
+    def test_double_block_index_ranges(self):
+        cases = [(0, FLUX_EARLY_DOWN), (3, FLUX_EARLY_DOWN),
+                 (4, FLUX_MID_DOWN), (7, FLUX_MID_DOWN),
+                 (8, FLUX_LATE_DOWN), (9, FLUX_LATE_DOWN),
+                 (10, FLUX_CORE), (18, FLUX_CORE)]
+        for index, expected in cases:
+            key = f"diffusion_model.double_blocks.{index}.img_mlp.0.weight"
+            self.assertEqual(classify_flux_key(key), expected, key)
+
+    def test_single_block_index_ranges(self):
+        cases = [(0, FLUX_CORE), (7, FLUX_CORE),
+                 (8, FLUX_EARLY_UP), (15, FLUX_EARLY_UP),
+                 (16, FLUX_MID_UP), (31, FLUX_MID_UP),
+                 (32, FLUX_LATE_UP), (37, FLUX_LATE_UP)]
+        for index, expected in cases:
+            key = f"diffusion_model.single_blocks.{index}.linear1.weight"
+            self.assertEqual(classify_flux_key(key), expected, key)
+
+    def test_single_is_not_shadowed_by_the_double_pattern(self):
+        # "single_transformer_blocks_3" also contains "transformer_blocks_3".
+        self.assertEqual(
+            classify_flux_key("single_transformer_blocks.3.attn.to_q.weight"),
+            FLUX_CORE,
+        )
+        self.assertEqual(
+            classify_flux_key("transformer_blocks.3.attn.to_q.weight"),
+            FLUX_EARLY_DOWN,
+        )
+
+    def test_head_and_tail_tokens(self):
+        cases = {
+            "diffusion_model.txt_in.weight": FLUX_TEXT_CONDITIONING,
+            "diffusion_model.time_in.in_layer.weight": FLUX_TIMESTEP,
+            "diffusion_model.img_in.weight": FLUX_IMAGE_HINT,
+            "diffusion_model.guidance_in.in_layer.weight": FLUX_GUIDANCE,
+            "diffusion_model.vector_in.in_layer.weight": FLUX_VECTOR,
+            "diffusion_model.final_layer.linear.weight": FLUX_FINAL,
+            "diffusion_model.final_layer.adaLN_modulation.1.weight": FLUX_FINAL,
+        }
+        for key, expected in cases.items():
+            self.assertEqual(classify_flux_key(key), expected, key)
+
+    def test_diffusers_head_tokens(self):
+        cases = {
+            "time_text_embed.guidance_embedder.linear_1.weight": FLUX_GUIDANCE,
+            "time_text_embed.text_embedder.linear_1.weight": FLUX_VECTOR,
+            "time_text_embed.timestep_embedder.linear_1.weight": FLUX_TIMESTEP,
+            "context_embedder.weight": FLUX_TEXT_CONDITIONING,
+            "x_embedder.weight": FLUX_IMAGE_HINT,
+            "proj_out.weight": FLUX_FINAL,
+        }
+        for key, expected in cases.items():
+            self.assertEqual(classify_flux_key(key), expected, key)
+
+    def test_block_keys_win_over_head_tokens(self):
+        # img_attn / txt_attn inside a block must not be read as img_in / txt_in.
+        self.assertEqual(
+            classify_flux_key("diffusion_model.double_blocks.0.img_attn.proj.weight"),
+            FLUX_EARLY_DOWN,
+        )
+        self.assertEqual(
+            classify_flux_key("diffusion_model.double_blocks.0.txt_mod.lin.weight"),
+            FLUX_EARLY_DOWN,
+        )
+
+    def test_unknown_key_falls_through_to_other(self):
+        self.assertEqual(classify_flux_key("diffusion_model.mystery.weight"), FLUX_OTHER)
+
+    def test_whole_flux_state_dict_shape_is_covered(self):
+        """No canonical FLUX.1 UNet key should land in 'Other Tensors'."""
+        keys = [
+            "diffusion_model.img_in.weight",
+            "diffusion_model.txt_in.weight",
+            "diffusion_model.time_in.in_layer.weight",
+            "diffusion_model.time_in.out_layer.weight",
+            "diffusion_model.vector_in.in_layer.weight",
+            "diffusion_model.guidance_in.in_layer.weight",
+            "diffusion_model.final_layer.linear.weight",
+        ]
+        for i in range(FLUX_DEFAULT_DEPTH):
+            keys += [
+                f"diffusion_model.double_blocks.{i}.img_attn.qkv.weight",
+                f"diffusion_model.double_blocks.{i}.txt_attn.proj.weight",
+                f"diffusion_model.double_blocks.{i}.img_mod.lin.weight",
+                f"diffusion_model.double_blocks.{i}.txt_mlp.2.weight",
+            ]
+        for i in range(FLUX_DEFAULT_DEPTH_SINGLE):
+            keys += [
+                f"diffusion_model.single_blocks.{i}.linear1.weight",
+                f"diffusion_model.single_blocks.{i}.linear2.weight",
+                f"diffusion_model.single_blocks.{i}.modulation.lin.weight",
+            ]
+        unclassified = [k for k in keys if classify_flux_key(k) == FLUX_OTHER]
+        self.assertEqual(unclassified, [])
+
+
+class TestSdxlClassification(unittest.TestCase):
+    def test_unet_stages(self):
+        cases = {
+            "diffusion_model.input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight":
+                SDXL_INPUT_BLOCKS,
+            "diffusion_model.middle_block.1.transformer_blocks.0.attn2.to_k.weight":
+                SDXL_MIDDLE_BLOCK,
+            "diffusion_model.output_blocks.5.1.proj_out.weight":
+                SDXL_OUTPUT_BLOCKS,
+            "diffusion_model.time_embed.0.weight": SDXL_OTHER,
+            "diffusion_model.label_emb.0.0.weight": SDXL_OTHER,
+            "diffusion_model.out.2.weight": SDXL_OTHER,
+        }
+        for key, expected in cases.items():
+            self.assertEqual(classify_sdxl_key(key), expected, key)
+
+    def test_nested_transformer_blocks_do_not_confuse_the_stage(self):
+        key = "diffusion_model.output_blocks.3.1.transformer_blocks.1.ff.net.0.proj.weight"
+        self.assertEqual(classify_sdxl_key(key), SDXL_OUTPUT_BLOCKS)
+
+
+class TestStrengthResolution(unittest.TestCase):
+    def test_custom_preset_uses_sliders_scaled_by_global_strength(self):
+        overrides = {name: 0.5 for name in ALL_SDXL_BLOCKS}
+        result = resolve_block_strengths("SDXL", "Custom", 2.0, overrides)
+        self.assertEqual(set(result), set(ALL_SDXL_BLOCKS))
+        for value in result.values():
+            self.assertAlmostEqual(value, 1.0)
+
+    def test_missing_slider_defaults_to_one(self):
+        result = resolve_block_strengths("SDXL", "Custom", 1.0, {})
+        self.assertAlmostEqual(result[SDXL_INPUT_BLOCKS], 1.0)
+
+    def test_named_preset_ignores_sliders(self):
+        overrides = {name: 0.0 for name in ALL_SDXL_BLOCKS}
+        result = resolve_block_strengths("SDXL", "Style", 1.0, overrides)
+        self.assertAlmostEqual(result[SDXL_OUTPUT_BLOCKS], 1.0)
+        self.assertAlmostEqual(result[SDXL_TEXT_ENCODER], 0.0)
+
+    def test_preset_strength_multiplies_global_strength(self):
+        # "Fix Hands/Anatomy" carries a preset strength of 0.4.
+        result = resolve_block_strengths("SDXL", "Fix Hands/Anatomy", 0.5, {})
+        self.assertAlmostEqual(result[SDXL_INPUT_BLOCKS], 0.2)
+
+    def test_negative_global_strength_inverts_every_block(self):
+        result = resolve_block_strengths("FLUX", "Full (Normal LoRA)", -1.0, {})
+        for value in result.values():
+            self.assertAlmostEqual(value, -1.0)
+
+    def test_full_preset_is_equivalent_to_a_plain_lora_load(self):
+        for family in ("FLUX", "SDXL"):
+            result = resolve_block_strengths(family, "Full (Normal LoRA)", 0.8, {})
+            for name, value in result.items():
+                self.assertAlmostEqual(value, 0.8, msg=f"{family}/{name}")
+
+
+class TestPresetIntegrity(unittest.TestCase):
+    def test_every_preset_covers_every_block(self):
+        for family, presets in LORA_BLOCK_PRESETS.items():
+            blocks = {"FLUX": ALL_FLUX_BLOCKS, "SDXL": ALL_SDXL_BLOCKS}[family]
+            for preset_name, config in presets.items():
+                if preset_name == "Custom":
+                    self.assertEqual(config, {})
+                    continue
+                weights = config["block_weights"]
+                self.assertEqual(set(weights), set(blocks),
+                                 f"{family}/{preset_name}")
+
+    def test_block_lists_have_no_duplicates(self):
+        for blocks in (ALL_FLUX_BLOCKS, ALL_SDXL_BLOCKS):
+            self.assertEqual(len(blocks), len(set(blocks)))
+
+    def test_widget_order_contract_is_preserved(self):
+        """Widget values are serialised positionally; only append to these."""
+        self.assertEqual(ALL_FLUX_BLOCKS[:14], [
+            "Text Conditioning",
+            "Timestep Embedding",
+            "Image Hint",
+            "Guidance Embedding",
+            "Vector Embedding",
+            "Early Downsampling (Composition)",
+            "Mid Downsampling (Subject & Concept)",
+            "Late Downsampling (Refinement)",
+            "Core/Middle Block (Style Focus)",
+            "Early Upsampling (Initial Style)",
+            "Mid Upsampling (Detail Generation)",
+            "Late Upsampling (Final Textures)",
+            "Final Output Layer (Latent Projection)",
+            "Other Tensors",
+        ])
+        self.assertEqual(ALL_FLUX_BLOCKS[14], FLUX_TEXT_ENCODER)
+        self.assertEqual(ALL_SDXL_BLOCKS[:4], [
+            "Text Encoder",
+            "Input Blocks",
+            "Middle Block",
+            "Output Blocks",
+        ])
+        self.assertEqual(ALL_SDXL_BLOCKS[4], SDXL_OTHER)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

The per-block sliders were not targeting the blocks they named — for **every** LoRA, in both loaders.

ComfyUI's `key_map` maps a LoRA's key name to the **model state-dict key string** the patch targets (or a `(key, offset)` tuple for fused FLUX `qkv` / `linear1` weights). `_invert_key_map` treated those values as `nn.Module` objects:

```python
inv[info[0]] = raw   # info is a str -> info[0] is its first *character*
```

So the inverted map ended up keyed by single characters, and `_flux_concept_from_raw` / `_split_sdxl_patches_by_block` resolved every patch through one arbitrary lookup. In practice all weights landed in a single bucket rather than being split per block.

The fix is also a simplification: classify directly on the canonical target key. ComfyUI has already translated every exporter dialect (kohya `lora_unet_*`, OneTrainer `lora_transformer_*`, diffusers `transformer.*`, LyCORIS, DiffSynth, PEFT) into those names, so the mapping becomes dialect-proof instead of a pile of per-format regexes. Fused `(key, offset)` patches are unpacked correctly.

## Other fixes

- **SDXL dropped patches silently.** Anything not matching input/middle/output/text-encoder was collected into `p_other` and then never applied. Those tensors now have their own `Other Tensors` weight.
- **Model/CLIP routing.** The FLUX loader pushed every group into *both* the model and the CLIP patcher at the same block strength, with no separate text-encoder control. Model and text-encoder patches are now split by which key map owns the key, and FLUX gains a `Text Encoder` slider.
- **Dead FLUX index ranges.** The table mapped `double_blocks.19–28`, which exist on no FLUX model (FLUX.1 has 19 double / 38 single). Ranges are now derived from the loaded model's own `depth` / `depth_single_blocks`, so pruned and distilled variants map correctly too.
- **`torch.load` without `weights_only`.** Non-safetensors LoRAs now go through `comfy.utils.load_torch_file(..., safe_load=True)`, so loading a `.ckpt`/`.pt` LoRA cannot execute pickled code.

## Improvements

- LoRA file caching keyed on path/size/mtime, instead of re-reading from disk on every graph execution.
- New `info` string output with a per-block weight / found / applied table, plus logging that explains empty blocks.
- `comfy.lora_convert` support (guarded by `try/except ImportError`) for BFL-control, Wan-Fun and USO LoRAs.
- Optional `clip` input, widget tooltips, node `DESCRIPTION`s, and a `Detail & Texture` preset for both families.
- Missing / unreadable / non-matching LoRAs return the inputs unchanged with an explanation on `info` rather than only logging.
- The two loaders now share one pipeline via a small base class.

## Testing

Mapping logic moved to `bobs_blocks.py`, which imports neither ComfyUI nor torch, so it is testable on a bare interpreter:

```
$ python -m unittest discover -s tests
Ran 25 tests in 0.004s
OK
```

Coverage includes both index-range tables, the `single_transformer_blocks` / `transformer_blocks` regex shadowing case, head-token vs block-key precedence (`img_attn` must not read as `img_in`), full-state-dict sweeps asserting nothing falls into `Other Tensors`, non-standard FLUX depths, preset/slider precedence, and the widget-order contract. A `tests.yml` workflow runs them on 3.9 and 3.12.

The node itself was additionally exercised end-to-end against stub `comfy.lora` / `comfy.utils` modules mirroring the real API — including diffusers `(key, offset)` tuple targets — verifying per-block counts, that the input model and clip are never mutated, model-only operation, and the error paths.

## Compatibility

Existing workflows keep working: new widgets are appended after the existing ones and new outputs after the existing ones, so saved widget values and links stay aligned. Expect *different* — correct — results from the same slider settings, since the sliders previously did not target the blocks they named.

`pyproject.toml` bumped to 1.1.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUT2wQ8UsjNgosRWu6jvpj)_