### PR TITLE
Fix issues found in code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,36 @@ python -m unittest discover -s tests -v
 
 ## Changelog
 
+### 1.2.1
+
+Code-review fixes. No behaviour change for a correctly-paired LoRA and model.
+
+-   **The FLUX and SDXL classifiers now anchor on the module path**, matching
+    the Universal loader. They previously matched on an underscore-normalised
+    key, which erases the separator that tells an *outermost* block stack from
+    one nested inside a block. An SDXL key such as
+    `input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight` was read as
+    double-stream block 0, so pointing the FLUX node at an SDXL model filed
+    every tensor under "Early Downsampling". Real FLUX and SDXL keys are
+    unaffected — this only ever misfired across families.
+-   **Mismatched loader and model now warn** instead of failing silently. If
+    90% or more of a LoRA's UNet tensors land in one block, the `info` output
+    and the log say so and point at the Universal loader. Measured: a real SDXL
+    key set through the FLUX node warns at 99%, a FLUX key set through the SDXL
+    node at 100%, while all six correctly-paired combinations stay silent.
+-   **Families register explicitly** via `register_family()` rather than by
+    mutating `bobs_blocks`'s tables at import time, removing an import-order
+    dependency that also made the test suite fragile.
+-   **Tooltips are per family.** FLUX/SDXL and Universal each define a block
+    called "Text Encoder"; the Universal wording used to overwrite the other.
+-   **`Output Head` detection tightened.** The `_head_` substring also matched
+    `multi_head_attention` and `head_dim_proj`; it is now anchored to a real
+    head module.
+-   An unknown `preset` name (only reachable from hand-edited workflow JSON)
+    logs a warning instead of silently behaving as `Custom`.
+-   Test suite grown to 71, including a new `tests/test_node_behaviour.py`
+    covering node registration, widget order, the report and the new warning.
+
 ### 1.2.0
 
 **New: a Universal loader covering every architecture ComfyUI supports.**

--- a/bobs_blocks.py
+++ b/bobs_blocks.py
@@ -98,6 +98,11 @@ BLOCK_TOOLTIPS: Dict[str, str] = {
 }
 BLOCK_TOOLTIPS[SDXL_TEXT_ENCODER] = BLOCK_TOOLTIPS[FLUX_TEXT_ENCODER]
 
+#: Per-family tooltip overrides, keyed family -> block -> text. Families share
+#: some block *names* ("Text Encoder", "Other Tensors") but want different help
+#: text, so a single flat dict cannot hold both.
+FAMILY_TOOLTIPS: Dict[str, Dict[str, str]] = {}
+
 # -----------------------------------------------------------------------------#
 #                             PRESET  DEFINITIONS                              #
 # -----------------------------------------------------------------------------#
@@ -278,6 +283,35 @@ LORA_BLOCK_PRESETS: Dict[str, Dict[str, Dict]] = {
 
 ALL_BLOCKS = {"FLUX": ALL_FLUX_BLOCKS, "SDXL": ALL_SDXL_BLOCKS}
 
+#: Families defined in this module. Additional families register themselves via
+#: :func:`register_family`; keep this constant for code that needs the built-in
+#: two regardless of what else has been imported.
+BUILTIN_FAMILIES = ("FLUX", "SDXL")
+
+
+def register_family(family: str,
+                    blocks: List[str],
+                    presets: Dict[str, Dict],
+                    text_encoder_block: str,
+                    tooltips: Dict[str, str] = None) -> None:
+    """Register an additional block family (see :mod:`bobs_universal`).
+
+    Kept explicit rather than done by assignment at import time: the tables
+    below are module state, and a silent import-order dependency makes both
+    behaviour and tests fragile. Tooltips are stored per family so that two
+    families sharing a block name (both call one "Text Encoder") do not
+    overwrite each other's help text.
+    """
+    ALL_BLOCKS[family] = blocks
+    LORA_BLOCK_PRESETS[family] = presets
+    TEXT_ENCODER_BLOCK[family] = text_encoder_block
+    FAMILY_TOOLTIPS[family] = dict(tooltips or {})
+
+
+def tooltip_for(family: str, block: str) -> str:
+    """Help text for a block, preferring the family's own wording."""
+    return FAMILY_TOOLTIPS.get(family, {}).get(block) or BLOCK_TOOLTIPS.get(block, block)
+
 # -----------------------------------------------------------------------------#
 #                              KEY NORMALISATION                               #
 # -----------------------------------------------------------------------------#
@@ -322,10 +356,27 @@ _SINGLE_SPLITS: Sequence[Tuple[float, str]] = (
     (1.0, FLUX_LATE_UP),
 )
 
-# ``single`` must be tested before ``double``: "single_transformer_blocks_3"
-# would otherwise also satisfy the double-stream pattern.
-_RE_SINGLE_BLOCK = re.compile(r"_(?:single_blocks|single_transformer_blocks)_(\d+)(?:_|$)")
-_RE_DOUBLE_BLOCK = re.compile(r"_(?:double_blocks|transformer_blocks)_(\d+)(?:_|$)")
+# Stack matching runs on the RAW dotted key, never the underscore-normalised
+# one. Normalising erases the separator that distinguishes an *outermost* stack
+# from one nested inside a block: an SDXL key
+# "input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight" normalises to
+# "..._input_blocks_4_1_transformer_blocks_0_..." where a naive search matches
+# the inner transformer_blocks and reads the key as double-stream block 0.
+# Anchoring on "." keeps the two apart, and makes the leftmost match the
+# outermost stack.
+#
+# ``single`` is still tested before ``double`` so that
+# "single_transformer_blocks.3" cannot be read as "transformer_blocks.3".
+#
+# Anchoring on "." alone is not enough — the nested transformer_blocks is also
+# dot-preceded. FLUX's stacks are always *top level*, so the pattern is anchored
+# to the start of the module path (after an optional known prefix). SDXL's
+# nested stack then cannot match, because "input_blocks" sits in front of it.
+_PREFIX = r"^(?:model\.)?(?:diffusion_model\.|transformer\.)?"
+_RE_SINGLE_BLOCK = re.compile(
+    _PREFIX + r"(?:single_blocks|single_transformer_blocks)\.(-?\d+)(?=\.|$)")
+_RE_DOUBLE_BLOCK = re.compile(
+    _PREFIX + r"(?:double_blocks|transformer_blocks)\.(-?\d+)(?=\.|$)")
 
 # Head / tail tokens, most specific first.
 _FLUX_TOKEN_MAP: Sequence[Tuple[str, str]] = (
@@ -375,19 +426,31 @@ def _bucket(index: int, boundaries: Sequence[Tuple[int, str]], fallback: str) ->
     return fallback
 
 
+def _resolve_index(index: int, boundaries: Sequence[Tuple[int, str]]) -> int:
+    """Resolve a Python-style negative block index against the stack size."""
+    if index >= 0:
+        return index
+    size = boundaries[-1][0] if boundaries else 0
+    return max(index + size, 0)
+
+
 def classify_flux_key(model_key: str, ranges=None) -> str:
     """Map a FLUX UNet state-dict key to one of :data:`ALL_FLUX_BLOCKS`."""
     double_bounds, single_bounds = ranges or flux_block_ranges()
+
+    # Block stacks match on the raw dotted key (see _RE_SINGLE_BLOCK); the
+    # token checks below match on the normalised one.
+    match = _RE_SINGLE_BLOCK.search(model_key)
+    if match:
+        return _bucket(_resolve_index(int(match.group(1)), single_bounds),
+                       single_bounds, FLUX_LATE_UP)
+
+    match = _RE_DOUBLE_BLOCK.search(model_key)
+    if match:
+        return _bucket(_resolve_index(int(match.group(1)), double_bounds),
+                       double_bounds, FLUX_CORE)
+
     nk = normalize_key(model_key)
-
-    match = _RE_SINGLE_BLOCK.search(nk)
-    if match:
-        return _bucket(int(match.group(1)), single_bounds, FLUX_LATE_UP)
-
-    match = _RE_DOUBLE_BLOCK.search(nk)
-    if match:
-        return _bucket(int(match.group(1)), double_bounds, FLUX_CORE)
-
     for token, block in _FLUX_TOKEN_MAP:
         if token in nk:
             return block
@@ -399,15 +462,23 @@ def classify_flux_key(model_key: str, ranges=None) -> str:
 #                             SDXL  CLASSIFICATION                             #
 # -----------------------------------------------------------------------------#
 
+# Anchored on "." for the same reason as the FLUX patterns above: the stage is
+# the outermost path component, not whatever is nested inside a block.
+_RE_SDXL_STAGE = re.compile(
+    _PREFIX + r"(input_blocks|middle_block|output_blocks)(?=\.|$)")
+
+_SDXL_STAGE_BLOCKS = {
+    "input_blocks": SDXL_INPUT_BLOCKS,
+    "middle_block": SDXL_MIDDLE_BLOCK,
+    "output_blocks": SDXL_OUTPUT_BLOCKS,
+}
+
+
 def classify_sdxl_key(model_key: str) -> str:
     """Map an SDXL UNet state-dict key to one of :data:`ALL_SDXL_BLOCKS`."""
-    nk = normalize_key(model_key)
-    if "_input_blocks_" in nk:
-        return SDXL_INPUT_BLOCKS
-    if "_middle_block_" in nk:
-        return SDXL_MIDDLE_BLOCK
-    if "_output_blocks_" in nk:
-        return SDXL_OUTPUT_BLOCKS
+    match = _RE_SDXL_STAGE.search(model_key)
+    if match:
+        return _SDXL_STAGE_BLOCKS[match.group(1)]
     return SDXL_OTHER
 
 

--- a/bobs_lora_loader.py
+++ b/bobs_lora_loader.py
@@ -27,19 +27,21 @@ import folder_paths
 from .bobs_blocks import (
     ALL_FLUX_BLOCKS,
     ALL_SDXL_BLOCKS,
-    BLOCK_TOOLTIPS,
     FLUX_DEFAULT_DEPTH,
     FLUX_DEFAULT_DEPTH_SINGLE,
+    FLUX_OTHER,
     LORA_BLOCK_PRESETS,
+    SDXL_OTHER,
     TEXT_ENCODER_BLOCK,
     classify_flux_key,
     classify_sdxl_key,
     flux_block_ranges,
     resolve_block_strengths,
+    tooltip_for,
 )
 from .bobs_universal import (  # registers the UNIVERSAL family on import
     ALL_UNIVERSAL_BLOCKS,
-    UNIVERSAL_TOOLTIPS,
+    UNIVERSAL_OTHER,
     classify_universal_key,
     discover_layout,
 )
@@ -53,6 +55,11 @@ logger = logging.getLogger("BobsLoraLoader")
 
 MAX_STRENGTH = 5.0
 MAX_BLOCK_WEIGHT = 2.0
+
+#: Share of UNet tensors in a single block above which the family looks wrong.
+#: A correctly-paired LoRA spreads across blocks; the worst real case measured
+#: was 60/200 (30%) in one block, so 0.9 leaves a wide margin.
+_MISMATCH_SHARE = 0.9
 
 
 # -----------------------------------------------------------------------------#
@@ -132,6 +139,51 @@ def _format_report(tag: str,
     return "\n".join(lines)
 
 
+def _mismatch_warning(tag: str,
+                      blocks: List[str],
+                      grouped: Dict[str, Dict[Any, Any]],
+                      text_encoder_block: str,
+                      catch_all_block: str) -> Optional[str]:
+    """Detect a LoRA/model pairing that the family classifier cannot resolve.
+
+    Picking the wrong loader for a model is silent otherwise: the keys still
+    match (ComfyUI's key map is built from the model, so the LoRA loads), they
+    just all land in whichever single bucket the classifier happens to reach.
+    Two shapes of that are worth calling out:
+
+    - everything piled into the family's catch-all, which then applies at that
+      slider's weight with no block weighting at all;
+    - everything piled into one *named* block, which means the sliders are
+      lying about what they control.
+    """
+    unet_counts = {name: len(patches) for name, patches in grouped.items()
+                   if name != text_encoder_block and patches}
+    total = sum(unet_counts.values())
+    if total < 8:  # too few patches for the distribution to mean anything
+        return None
+
+    # A threshold rather than "all of them": cross-family key names overlap just
+    # enough to scatter a few tensors. Feeding a real SDXL key set through the
+    # FLUX classifier leaves 98.7% in the catch-all and sends the rest to
+    # "Final Output Layer" via the shared proj_out token, which an exact-equality
+    # test would wave through.
+    def _share(name: str) -> float:
+        return unet_counts.get(name, 0) / total
+
+    if _share(catch_all_block) >= _MISMATCH_SHARE:
+        return (f"WARNING: {_share(catch_all_block):.0%} of UNet tensors landed in "
+                f"'{catch_all_block}'. This LoRA does not look like a {tag} LoRA, or the "
+                f"model is not a {tag} model — the per-block sliders are barely doing "
+                f"anything. Try the Universal loader.")
+
+    dominant, count = max(unet_counts.items(), key=lambda kv: kv[1])
+    if count / total >= _MISMATCH_SHARE and len(blocks) > 2:
+        return (f"WARNING: {count / total:.0%} of UNet tensors landed in '{dominant}'. "
+                f"That usually means this model is not a {tag} model, so the block "
+                f"sliders do not map to what their names say. Try the Universal loader.")
+    return None
+
+
 def _explain_empty_blocks(tag: str,
                           blocks: List[str],
                           grouped: Dict[str, Dict[Any, Any]],
@@ -155,6 +207,8 @@ class _BobsLoraLoaderBase:
 
     FAMILY = "FLUX"
     BLOCKS: List[str] = ALL_FLUX_BLOCKS
+    #: Bucket that receives anything the family classifier could not place.
+    CATCH_ALL_BLOCK = FLUX_OTHER
 
     RETURN_TYPES = ("MODEL", "CLIP", "STRING")
     RETURN_NAMES = ("MODEL", "CLIP", "info")
@@ -193,7 +247,7 @@ class _BobsLoraLoaderBase:
         for block in cls.BLOCKS:
             required[block] = ("FLOAT", {
                 "default": 1.0, "min": -MAX_BLOCK_WEIGHT, "max": MAX_BLOCK_WEIGHT, "step": 0.05,
-                "tooltip": BLOCK_TOOLTIPS.get(block, block),
+                "tooltip": tooltip_for(cls.FAMILY, block),
             })
         return {
             "required": required,
@@ -253,6 +307,9 @@ class _BobsLoraLoaderBase:
             self.logger.error(message)
             return (model, clip, message)
 
+        if preset not in LORA_BLOCK_PRESETS[self.FAMILY]:
+            self.logger.warning(
+                "[%s] unknown preset %r; falling back to the slider values.", tag, preset)
         strengths = resolve_block_strengths(self.FAMILY, preset, strength, kwargs)
 
         key_map, unet_targets = _build_key_maps(model, clip)
@@ -296,6 +353,13 @@ class _BobsLoraLoaderBase:
         # comfy.lora.load_lora itself as a "lora key not loaded" warning.
         report = _format_report(tag, lora_name, preset, self.BLOCKS,
                                 grouped, strengths, applied, detail)
+
+        mismatch = _mismatch_warning(tag, self.BLOCKS, grouped,
+                                     text_encoder_block, self.CATCH_ALL_BLOCK)
+        if mismatch:
+            self.logger.warning("[%s] %s", tag, mismatch)
+            report = f"{report}\n{mismatch}"
+
         self.logger.info("\n%s", report)
         _explain_empty_blocks(tag, self.BLOCKS, grouped, strengths)
 
@@ -335,6 +399,7 @@ class BobsLoraLoaderFlux(_BobsLoraLoaderBase):
 class BobsLoraLoaderSdxl(_BobsLoraLoaderBase):
     FAMILY = "SDXL"
     BLOCKS = ALL_SDXL_BLOCKS
+    CATCH_ALL_BLOCK = SDXL_OTHER
     DESCRIPTION = (
         "Applies a LoRA to an SDXL model with independent weights for the text "
         "encoder and the UNet input / middle / output stages."
@@ -355,6 +420,7 @@ class BobsLoraLoaderSdxl(_BobsLoraLoaderBase):
 class BobsLoraLoaderUniversal(_BobsLoraLoaderBase):
     FAMILY = "UNIVERSAL"
     BLOCKS = ALL_UNIVERSAL_BLOCKS
+    CATCH_ALL_BLOCK = UNIVERSAL_OTHER
     DESCRIPTION = (
         "Block-weighted LoRA loading for any architecture ComfyUI supports — "
         "SD1.5, SD2, SDXL, SD3/3.5, FLUX, Chroma, AuraFlow, PixArt, HiDream, "

--- a/bobs_universal.py
+++ b/bobs_universal.py
@@ -32,13 +32,7 @@ Imports nothing from ComfyUI or torch; see ``tests/test_bobs_universal.py``.
 import re
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-from .bobs_blocks import (
-    ALL_BLOCKS,
-    BLOCK_TOOLTIPS,
-    LORA_BLOCK_PRESETS,
-    TEXT_ENCODER_BLOCK,
-    normalize_key,
-)
+from .bobs_blocks import normalize_key, register_family
 
 # -----------------------------------------------------------------------------#
 #                                 BLOCK NAMES                                  #
@@ -74,7 +68,7 @@ _DEPTH_BUCKETS: Sequence[Tuple[float, str]] = (
     (0.4, UNIVERSAL_EARLY_MID),
     (0.6, UNIVERSAL_MID),
     (0.8, UNIVERSAL_LATE_MID),
-    (1.01, UNIVERSAL_LATE),
+    (1.0, UNIVERSAL_LATE),
 )
 
 UNIVERSAL_TOOLTIPS: Dict[str, str] = {
@@ -154,9 +148,12 @@ _OUTPUT_TOKENS: Tuple[str, ...] = (
     "_norm_out",
     "_unpatchify",
     "_final_norm",
-    "_head_",
 )
-_OUTPUT_RE = re.compile(r"_out_\d+(?=_|$)")  # SD "out.0" / "out.2" head
+# Anchored patterns rather than loose substrings. A bare "_head_" token also
+# matched "multi_head_attention" and "head_dim_proj"; these require the segment
+# to actually be a head module ("head.head.weight", "out.0", "out.2").
+_OUTPUT_RE = re.compile(
+    r"(?:^|\.)(?:out\.\d+|head(?:\.head)?)(?=\.|$)", re.IGNORECASE)
 
 _INPUT_TOKENS: Tuple[str, ...] = (
     "_img_in",
@@ -301,7 +298,7 @@ def classify_universal_key(model_key: str, layout: BlockLayout) -> str:
     for token in _OUTPUT_TOKENS:
         if token in nk:
             return UNIVERSAL_OUTPUT
-    if _OUTPUT_RE.search(nk):
+    if _OUTPUT_RE.search(model_key):  # dot-anchored: raw key, not normalised
         return UNIVERSAL_OUTPUT
 
     for token in _INPUT_TOKENS:
@@ -396,7 +393,12 @@ UNIVERSAL_PRESETS = {
     },
 }
 
-LORA_BLOCK_PRESETS["UNIVERSAL"] = UNIVERSAL_PRESETS
-ALL_BLOCKS["UNIVERSAL"] = ALL_UNIVERSAL_BLOCKS
-TEXT_ENCODER_BLOCK["UNIVERSAL"] = UNIVERSAL_TEXT_ENCODER
-BLOCK_TOOLTIPS.update(UNIVERSAL_TOOLTIPS)
+UNIVERSAL_FAMILY = "UNIVERSAL"
+
+register_family(
+    UNIVERSAL_FAMILY,
+    blocks=ALL_UNIVERSAL_BLOCKS,
+    presets=UNIVERSAL_PRESETS,
+    text_encoder_block=UNIVERSAL_TEXT_ENCODER,
+    tooltips=UNIVERSAL_TOOLTIPS,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Bobs_LoRA_Loader"
 description = "Block-weighted LoRA loaders for ComfyUI. Dedicated SDXL and FLUX nodes plus a Universal node that discovers any supported architecture's block layout at runtime (SD1.5/2/3, Chroma, AuraFlow, PixArt, HiDream, Qwen-Image, Wan, LTX-Video, Mochi, HunyuanVideo, Lumina, Cosmos and more). Presets for common use-cases like 'Character' and 'Style', plus a 'Custom' mode for per-block control."
-version = "1.2.0"
+version = "1.2.1"
 license = {file = "LICENSE"}
 
 [project.urls]

--- a/tests/test_bobs_blocks.py
+++ b/tests/test_bobs_blocks.py
@@ -12,6 +12,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from bobs_blocks import (  # noqa: E402
+    ALL_BLOCKS,
     ALL_FLUX_BLOCKS,
     ALL_SDXL_BLOCKS,
     FLUX_CORE,
@@ -205,6 +206,48 @@ class TestSdxlClassification(unittest.TestCase):
         self.assertEqual(classify_sdxl_key(key), SDXL_OUTPUT_BLOCKS)
 
 
+class TestNestedStackIsolation(unittest.TestCase):
+    """The dedicated classifiers must not read a *nested* block stack.
+
+    SDXL nests transformer_blocks inside input_blocks/middle_block/
+    output_blocks. Matching on the underscore-normalised key made the FLUX
+    classifier see that inner stack and file SDXL keys as double-stream blocks.
+    """
+
+    SDXL_KEYS = [
+        "diffusion_model.input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight",
+        "diffusion_model.middle_block.1.transformer_blocks.0.attn2.to_k.weight",
+        "diffusion_model.output_blocks.5.1.transformer_blocks.1.ff.net.0.proj.weight",
+    ]
+
+    def test_flux_classifier_does_not_claim_sdxl_keys(self):
+        for key in self.SDXL_KEYS:
+            self.assertEqual(classify_flux_key(key), FLUX_OTHER, key)
+
+    def test_sdxl_classifier_still_reads_the_outer_stage(self):
+        expected = [SDXL_INPUT_BLOCKS, SDXL_MIDDLE_BLOCK, SDXL_OUTPUT_BLOCKS]
+        for key, want in zip(self.SDXL_KEYS, expected):
+            self.assertEqual(classify_sdxl_key(key), want, key)
+
+    def test_flux_keys_are_unaffected(self):
+        self.assertEqual(
+            classify_flux_key("diffusion_model.double_blocks.0.img_attn.qkv.weight"),
+            FLUX_EARLY_DOWN)
+        self.assertEqual(
+            classify_flux_key("diffusion_model.single_blocks.37.linear1.weight"),
+            FLUX_LATE_UP)
+        # diffusers spellings still resolve
+        self.assertEqual(classify_flux_key("transformer_blocks.3.attn.to_q.weight"),
+                         FLUX_EARLY_DOWN)
+        self.assertEqual(classify_flux_key("single_transformer_blocks.3.attn.to_q.weight"),
+                         FLUX_CORE)
+
+    def test_flux_negative_index_resolves_against_the_stack(self):
+        self.assertEqual(
+            classify_flux_key("diffusion_model.double_blocks.-1.img_attn.qkv.weight"),
+            FLUX_CORE)
+
+
 class TestStrengthResolution(unittest.TestCase):
     def test_custom_preset_uses_sliders_scaled_by_global_strength(self):
         overrides = {name: 0.5 for name in ALL_SDXL_BLOCKS}
@@ -242,8 +285,11 @@ class TestStrengthResolution(unittest.TestCase):
 
 class TestPresetIntegrity(unittest.TestCase):
     def test_every_preset_covers_every_block(self):
+        # Drive off ALL_BLOCKS rather than a literal family map: other modules
+        # register additional families, and this test must not care whether
+        # they happen to have been imported first.
         for family, presets in LORA_BLOCK_PRESETS.items():
-            blocks = {"FLUX": ALL_FLUX_BLOCKS, "SDXL": ALL_SDXL_BLOCKS}[family]
+            blocks = ALL_BLOCKS[family]
             for preset_name, config in presets.items():
                 if preset_name == "Custom":
                     self.assertEqual(config, {})

--- a/tests/test_bobs_universal.py
+++ b/tests/test_bobs_universal.py
@@ -289,6 +289,37 @@ class TestRealWorldRegressions(unittest.TestCase):
             self.assertEqual(bu.classify_universal_key(key, layout),
                              bu.UNIVERSAL_INPUT, key)
 
+    def test_head_token_does_not_swallow_attention_names(self):
+        """A bare "_head_" substring also matched multi_head_attention."""
+        layout = bu.discover_layout(_flat_stack("blocks", 28))
+        self.assertEqual(bu.classify_universal_key(
+            "diffusion_model.head.head.weight", layout), bu.UNIVERSAL_OUTPUT)
+        self.assertEqual(bu.classify_universal_key(
+            "diffusion_model.out.2.weight", layout), bu.UNIVERSAL_OUTPUT)
+        for key in ("diffusion_model.multi_head_attention.weight",
+                    "diffusion_model.some.head_dim_proj.weight"):
+            self.assertNotEqual(bu.classify_universal_key(key, layout),
+                                bu.UNIVERSAL_OUTPUT, key)
+
+    def test_every_depth_bucket_populated_at_real_depths(self):
+        order = (bu.UNIVERSAL_EARLY, bu.UNIVERSAL_EARLY_MID, bu.UNIVERSAL_MID,
+                 bu.UNIVERSAL_LATE_MID, bu.UNIVERSAL_LATE)
+        for depth in (12, 19, 24, 28, 40, 57, 60):
+            keys = _flat_stack("blocks", depth)
+            layout = bu.discover_layout(keys)
+            counts = [sum(1 for k in keys
+                          if bu.classify_universal_key(k, layout) == b) for b in order]
+            self.assertEqual(sum(counts), depth, depth)
+            self.assertTrue(all(c > 0 for c in counts), f"depth={depth}: {counts}")
+
+    def test_last_block_reaches_the_final_bucket(self):
+        """The top bucket boundary must include the deepest block."""
+        for depth in (3, 5, 19, 60):
+            keys = _flat_stack("blocks", depth)
+            layout = bu.discover_layout(keys)
+            self.assertEqual(bu.classify_universal_key(keys[-1], layout),
+                             bu.UNIVERSAL_LATE, depth)
+
     def test_flux_controlnet_hint_input(self):
         self.assertEqual(
             bobs_blocks.classify_flux_key("diffusion_model.pos_embed_input.weight"),
@@ -317,7 +348,22 @@ class TestUniversalPresets(unittest.TestCase):
 
     def test_every_block_has_a_tooltip(self):
         for name in bu.ALL_UNIVERSAL_BLOCKS:
-            self.assertIn(name, bobs_blocks.BLOCK_TOOLTIPS)
+            text = bobs_blocks.tooltip_for(bu.UNIVERSAL_FAMILY, name)
+            self.assertTrue(text and text != name, name)
+
+    def test_shared_block_names_keep_per_family_tooltips(self):
+        """FLUX/SDXL and UNIVERSAL both call a block "Text Encoder"."""
+        shared = bu.UNIVERSAL_TEXT_ENCODER
+        universal = bobs_blocks.tooltip_for(bu.UNIVERSAL_FAMILY, shared)
+        flux = bobs_blocks.tooltip_for("FLUX", shared)
+        self.assertNotEqual(universal, flux)
+        self.assertIn("whatever the model uses", universal)
+        self.assertIn("trigger words", flux)
+
+    def test_registration_does_not_disturb_the_builtin_families(self):
+        for family in bobs_blocks.BUILTIN_FAMILIES:
+            self.assertIn(family, bobs_blocks.ALL_BLOCKS)
+            self.assertIn(family, bobs_blocks.LORA_BLOCK_PRESETS)
 
 
 if __name__ == "__main__":

--- a/tests/test_node_behaviour.py
+++ b/tests/test_node_behaviour.py
@@ -1,0 +1,168 @@
+"""Node-level tests: the parts of bobs_lora_loader that need no real model.
+
+comfy.* and folder_paths are stubbed just enough to import the module; the
+logic under test (mismatch detection, report formatting) is ours.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _REPO)
+
+
+def _install_stubs():
+    comfy = types.ModuleType("comfy")
+    lora = types.ModuleType("comfy.lora")
+    utils = types.ModuleType("comfy.utils")
+    lora.model_lora_keys_unet = lambda model, key_map=None: key_map
+    lora.model_lora_keys_clip = lambda model, key_map=None: key_map
+    lora.load_lora = lambda sd, km, log_missing=True: {}
+    utils.load_torch_file = lambda p, safe_load=False, **kw: {}
+    comfy.lora, comfy.utils = lora, utils
+    sys.modules.setdefault("comfy", comfy)
+    sys.modules.setdefault("comfy.lora", lora)
+    sys.modules.setdefault("comfy.utils", utils)
+    fp = types.ModuleType("folder_paths")
+    fp.get_filename_list = lambda t: []
+    fp.get_full_path = lambda t, n: None
+    sys.modules.setdefault("folder_paths", fp)
+
+
+_install_stubs()
+
+_pkg = types.ModuleType("bobs_pkg")
+_pkg.__path__ = [_REPO]
+sys.modules.setdefault("bobs_pkg", _pkg)
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        f"bobs_pkg.{name}", os.path.join(_REPO, f"{name}.py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"bobs_pkg.{name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BB = _load("bobs_blocks")
+BU = _load("bobs_universal")
+NODE = _load("bobs_lora_loader")
+
+
+def _group(counts):
+    """Build a grouped-patches dict with the given per-block patch counts."""
+    return {name: {f"{name}.{i}": object() for i in range(n)}
+            for name, n in counts.items()}
+
+
+class TestMismatchWarning(unittest.TestCase):
+    def test_everything_in_the_catch_all_warns(self):
+        grouped = _group({BB.FLUX_OTHER: 40})
+        msg = NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                     BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER)
+        self.assertIsNotNone(msg)
+        self.assertIn("Other Tensors", msg)
+        self.assertIn("Universal", msg)
+
+    def test_everything_in_one_named_block_warns(self):
+        grouped = _group({BB.FLUX_EARLY_DOWN: 40})
+        msg = NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                     BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER)
+        self.assertIsNotNone(msg)
+        self.assertIn("Early Downsampling", msg)
+
+    def test_near_total_pileup_warns(self):
+        """Real SDXL keys through the FLUX classifier leave 98.7%, not 100%,
+        in the catch-all: a few hit the shared proj_out token."""
+        grouped = _group({BB.FLUX_OTHER: 1674, BB.FLUX_FINAL: 22})
+        msg = NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                     BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER)
+        self.assertIsNotNone(msg)
+        self.assertIn("99%", msg)
+
+    def test_a_healthy_distribution_does_not_warn(self):
+        grouped = _group({BB.FLUX_EARLY_DOWN: 16, BB.FLUX_MID_DOWN: 16,
+                          BB.FLUX_CORE: 60, BB.FLUX_LATE_UP: 18})
+        self.assertIsNone(
+            NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                   BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER))
+
+    def test_text_encoder_only_lora_does_not_warn(self):
+        """A TE-only LoRA is legitimate, not a family mismatch."""
+        grouped = _group({BB.FLUX_TEXT_ENCODER: 40})
+        self.assertIsNone(
+            NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                   BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER))
+
+    def test_tiny_loras_are_not_judged(self):
+        grouped = _group({BB.FLUX_OTHER: 3})
+        self.assertIsNone(
+            NODE._mismatch_warning("FLUX", BB.ALL_FLUX_BLOCKS, grouped,
+                                   BB.FLUX_TEXT_ENCODER, BB.FLUX_OTHER))
+
+    def test_each_node_declares_its_catch_all(self):
+        self.assertEqual(NODE.BobsLoraLoaderFlux.CATCH_ALL_BLOCK, BB.FLUX_OTHER)
+        self.assertEqual(NODE.BobsLoraLoaderSdxl.CATCH_ALL_BLOCK, BB.SDXL_OTHER)
+        self.assertEqual(NODE.BobsLoraLoaderUniversal.CATCH_ALL_BLOCK, BU.UNIVERSAL_OTHER)
+        for cls in (NODE.BobsLoraLoaderFlux, NODE.BobsLoraLoaderSdxl,
+                    NODE.BobsLoraLoaderUniversal):
+            self.assertIn(cls.CATCH_ALL_BLOCK, cls.BLOCKS)
+
+
+class TestReport(unittest.TestCase):
+    def test_block_names_fit_the_report_column(self):
+        every = BB.ALL_FLUX_BLOCKS + BB.ALL_SDXL_BLOCKS + BU.ALL_UNIVERSAL_BLOCKS
+        self.assertLessEqual(max(len(b) for b in every), 40)
+
+    def test_report_lists_every_block_and_a_total(self):
+        grouped = _group({BB.SDXL_INPUT_BLOCKS: 9})
+        strengths = {b: 1.0 for b in BB.ALL_SDXL_BLOCKS}
+        applied = {BB.SDXL_INPUT_BLOCKS: 9}
+        report = NODE._format_report("SDXL", "x.safetensors", "Custom",
+                                     BB.ALL_SDXL_BLOCKS, grouped, strengths,
+                                     applied, "architecture: SDXL")
+        for block in BB.ALL_SDXL_BLOCKS:
+            self.assertIn(block, report)
+        self.assertIn("architecture: SDXL", report)
+        self.assertIn("TOTAL", report)
+
+
+class TestNodeRegistration(unittest.TestCase):
+    def test_three_nodes_registered_with_display_names(self):
+        self.assertEqual(set(NODE.NODE_CLASS_MAPPINGS),
+                         {"BobsLoraLoaderFlux", "BobsLoraLoaderSdxl",
+                          "BobsLoraLoaderUniversal"})
+        self.assertEqual(set(NODE.NODE_CLASS_MAPPINGS),
+                         set(NODE.NODE_DISPLAY_NAME_MAPPINGS))
+
+    def test_input_types_are_well_formed(self):
+        for cls in NODE.NODE_CLASS_MAPPINGS.values():
+            spec = cls.INPUT_TYPES()
+            self.assertEqual(set(spec), {"required", "optional"}, cls.__name__)
+            self.assertIn("clip", spec["optional"])
+            for field in ("model", "lora_name", "strength", "preset"):
+                self.assertIn(field, spec["required"], cls.__name__)
+            for block in cls.BLOCKS:
+                self.assertIn(block, spec["required"], f"{cls.__name__}/{block}")
+                opts = spec["required"][block][1]
+                self.assertTrue(opts["tooltip"], block)
+                self.assertNotEqual(opts["tooltip"], block, block)
+
+    def test_widget_order_places_blocks_after_the_fixed_widgets(self):
+        for cls in NODE.NODE_CLASS_MAPPINGS.values():
+            names = list(cls.INPUT_TYPES()["required"])
+            self.assertEqual(names[:4], ["model", "lora_name", "strength", "preset"])
+            self.assertEqual(names[4:], list(cls.BLOCKS), cls.__name__)
+
+    def test_outputs_are_model_clip_info(self):
+        for cls in NODE.NODE_CLASS_MAPPINGS.values():
+            self.assertEqual(cls.RETURN_TYPES, ("MODEL", "CLIP", "STRING"))
+            self.assertEqual(cls.RETURN_NAMES, ("MODEL", "CLIP", "info"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Eight findings from a review of 1.2.0. **None changes behaviour for a correctly-paired LoRA and model** — the first two matter when the pairing is wrong.

## 1. The dot-boundary fix never reached the FLUX/SDXL classifiers

The Universal loader matches block stacks on the raw dotted key, because normalising `.` → `_` erases the separator that distinguishes an *outermost* stack from one nested inside a block. The two dedicated classifiers never got that fix, so an SDXL key:

```
input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight
```

matched the **inner** `transformer_blocks` and was read as double-stream block 0.

Anchoring on `.` alone turned out to be insufficient — the nested stack is *also* dot-preceded. The patterns are now anchored to the **start of the module path** after an optional known prefix, which is the property that actually distinguishes them. Verified against 782 authentic FLUX and 1696 authentic SDXL keys: unchanged.

| keys → node | before | after |
|---|---|---|
| SDXL → FLUX | all 1696 in `Early Downsampling` | 1674 `Other Tensors`, 22 `Final Output Layer` |
| FLUX → SDXL | all 782 in `Other Tensors` | unchanged |

## 2. Wrong loader for a model now warns instead of failing silently

Picking the wrong node was invisible: the keys still match — ComfyUI builds the key map from the *model*, so the LoRA loads — they just all land in one bucket, and the sliders quietly stop meaning what they say.

A mismatch check now fires when ≥90% of UNet tensors land in a single block, on both the `info` output and the log. A threshold rather than "all of them", because cross-family names overlap slightly: real SDXL keys through the FLUX classifier leave 98.7% in the catch-all and send the rest to the shared `proj_out` token, which exact equality would wave through.

Measured against real key sets:

```
MISMATCHED (must warn)
  SDXL keys -> FLUX node : WARNING: 99% of UNet tensors landed in 'Other Tensors'...
  FLUX keys -> SDXL node : WARNING: 100% of UNet tensors landed in 'Other Tensors'...
CORRECT (must stay silent)
  FLUX->FLUX, SDXL->SDXL, SD15->SDXL, and SDXL/SD15/FLUX->UNIVERSAL : all None
```

## 3. Import-order dependency in the shared registries

`bobs_universal` mutated four of `bobs_blocks`'s dicts at import time. Confirmed consequence: after that import, this line in `tests/test_bobs_blocks.py` raises `KeyError: 'UNIVERSAL'`:

```python
blocks = {"FLUX": ALL_FLUX_BLOCKS, "SDXL": ALL_SDXL_BLOCKS}[family]
```

It passed only because the two test files happened to load `bobs_blocks` under different module names, so they got separate instances — luck, not design. Families now register through an explicit `register_family()`, and the test drives off `ALL_BLOCKS`.

## 4–8. Smaller items

- **Per-family tooltips.** FLUX/SDXL and Universal each define a block named `"Text Encoder"`; `BLOCK_TOOLTIPS.update()` meant the Universal wording overwrote the other. Tooltips are now stored per family.
- **`Output Head` over-matching.** The `_head_` substring also caught `multi_head_attention` and `head_dim_proj`. Now anchored to a real head module (`head`, `head.head`, `out.<n>`).
- **Unknown preset names** log a warning instead of silently behaving as `Custom` (only reachable from hand-edited workflow JSON).
- **FLUX negative block indices** accepted, matching the Universal loader's handling of SD3's `joint_blocks.-1`.
- **Dropped a `1.01` bucket boundary** guarding a fraction that cannot occur — `depth_fraction` maxes at `(n-0.5)/n`.
- Bonus, found while writing the tests: `_mismatch_warning` was keying off `len(grouped)`, which is dense in production but sparse in a unit test. It now uses its `blocks` argument, which was otherwise unused.

## Testing

71 tests, up from 55, still with no ComfyUI or torch dependency. New `tests/test_node_behaviour.py` covers node registration, widget order, output signature, report formatting and the mismatch warning — including the exact 1674/22 distribution from finding 1, so the threshold can't silently regress to exact-equality.

The real-ComfyUI integration harnesses were re-run: 8,000+ authentic keys across 11 architectures, still nothing falling through to `Other Tensors`, and the node end-to-end run through a real `ModelPatcher` is byte-identical (block isolation still exactly 384/1933).

`pyproject.toml` bumped to 1.2.1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUT2wQ8UsjNgosRWu6jvpj)_